### PR TITLE
Add macOS support

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -1,0 +1,58 @@
+using TOML, Base.BinaryPlatforms, Scratch
+
+struct BuildkiteRunnerGroup
+    # Group name, such as "surrogatization"
+    name::String
+
+    # Number of agents to spawn
+    num_agents::Int
+
+    # All the queues this runner will subscribe to
+    queues::Set{String}
+
+    # Any extra tags to be applied
+    tags::Dict{String,String}
+
+    # Whether this runner should spin up a rootless docker instance
+    # NOTE: this only works with `linux-sandbox.jl` runners!
+    start_rootless_docker::Bool
+
+    # Whether this runner should be run in verbose mode
+    verbose::Bool
+end
+
+function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{String,String} = Dict{String,String}())
+    queues = Set(split(get(config, "queues", "default"), ","))
+    num_agents = get(config, "num_agents", 1)
+    tags = get(config, "tags", Dict{String,String}())
+    start_rootless_docker = get(config, "start_rootless_docker", false)
+    verbose = get(config, "verbose", false)
+
+    # If we're going to start up a rootless docker instance, advertise it!
+    if start_rootless_docker
+        tags["docker_present"] = "true"
+    end
+
+    # Encode some information about this runner
+    merge!(tags, extra_tags)
+    tags["os"] = os(HostPlatform())
+    tags["arch"] = arch(HostPlatform())
+
+    return BuildkiteRunnerGroup(
+        string(name),
+        num_agents,
+        queues,
+        tags,
+        start_rootless_docker,
+        verbose,
+    )
+end
+
+function read_configs(config_file::String="config.toml"; kwargs...)
+    config = TOML.parsefile(config_file)
+
+    # Parse out each of the groups
+    return map(sort(collect(keys(config)))) do group_name
+        return BuildkiteRunnerGroup(group_name, config[group_name]; kwargs...)
+    end
+end

--- a/hooks/environment.d/101_julia_num_cores.sh
+++ b/hooks/environment.d/101_julia_num_cores.sh
@@ -4,5 +4,10 @@
 # If you want a different value, I suggest overriding this value within
 # another environment hook in your `environment.local.d` directory,
 # which is appropriately `.gitignore`'d to maintain a local config.
-JULIA_NUM_THREADS=$(($(nproc) > 16 ? 16 : $(nproc)))
-export JULIA_CPU_THREADS=${JULIA_NUM_THREADS}
+if [[ "$(uname)" == "Darwin" ]]; then
+    function nproc() {
+        sysctl -n "hw.ncpu"
+    }
+fi
+
+export JULIA_CPU_THREADS="$(($(nproc) > 16 ? 16 : $(nproc)))"

--- a/hooks/environment.d/999_cryptic_unlock.sh
+++ b/hooks/environment.d/999_cryptic_unlock.sh
@@ -2,6 +2,11 @@
 
 set -eou pipefail
 
+# Don't try to do this on anything but Linux for now
+if [[ "$(uname)" != "Linux" ]]; then
+    exit 0
+fi
+
 ## A foundational concept for the usage of this hook is that we can deny access to secrets
 ## (such as the agent private key or the build token file) by deleting or unmounting the
 ## `/secrets` folder.  This agent should always be running within some kind of sandbox,

--- a/hooks/environment.d/999_cryptic_unlock.sh
+++ b/hooks/environment.d/999_cryptic_unlock.sh
@@ -2,11 +2,6 @@
 
 set -eou pipefail
 
-# Don't try to do this on anything but Linux for now
-if [[ "$(uname)" != "Linux" ]]; then
-    exit 0
-fi
-
 ## A foundational concept for the usage of this hook is that we can deny access to secrets
 ## (such as the agent private key or the build token file) by deleting or unmounting the
 ## `/secrets` folder.  This agent should always be running within some kind of sandbox,
@@ -14,12 +9,18 @@ fi
 ## agent should exit, causing the docker container to restart and restore the deleted files.
 ## This gives us the capability to deny access to these files to later steps within the
 ## current buildkite job.
-SECRETS_MOUNT_POINT="/secrets"
+SECRETS_MOUNT_POINT="${BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT-:/secrets}"
 
 ## The secrets that must be contained within:
 ##    - `agent.{key,pub}`: An RSA private/public keypair (typically generated via the
 ##       script `bin/create_agent_keypair`).  See the top-level `README.md` for more.
 ##    - `buildkite-api-token`: A buildkite API token (with `read_builds` permission).
+
+## The helper programs that must be available on the worker:
+##    - openssl (from Homebrew on macOS)
+##    - shyaml
+##    - jq
+##    - shred (for Linux)
 
 # Helper function
 function die() {
@@ -36,21 +37,53 @@ function base64enc() {
     openssl base64 -e -A
 }
 
-# Set this to wherever your private key lives
-PRIVATE_KEY_PATH="${SECRETS_MOUNT_POINT}/agent.key"
-PUBLIC_KEY_PATH="${SECRETS_MOUNT_POINT}/agent.pub"
-if [[ ! -f "${PRIVATE_KEY_PATH}" ]]; then
-    die "Unable to open agent private key path '${PRIVATE_KEY_PATH}'!  Make sure your agent has this file deployed within it!"
+# Figure out the best way to securely delete something
+if [[ -n "$(which shred 2>/dev/null)" ]]; then
+    function secure_delete() {
+        shred -u "$*"
+    }
+elif [[ "$(uname)" == "Darwin" ]] || [[ "$(uname)" == *BSD ]]; then
+    function secure_delete() {
+        rm -fP "$*"
+    }
 else
-    if ! openssl rsa -inform PEM -in "${PRIVATE_KEY_PATH}" -noout 2>/dev/null; then
-        die "Secret private key path '${PRIVATE_KEY_PATH}' is not a valid private RSA key!"
+    # Suboptimal, but what you gonna do?
+    function secure_delete() {
+        rm -f "$*"
+    }
+fi
+
+function cleanup_secrets() {
+    ## Cleanup: Deny access to secrets to future pipeline steps by either unmounting `/secrets`
+    #  or just deleting the files inside, if that doesn't work.  If neither work, we abort the build.
+    if ! umount "${SECRETS_MOUNT_POINT}" 2>/dev/null; then
+        if ! rm -rf "${SECRETS_MOUNT_POINT}"; then
+            die "Unable to unmount secrets at '${SECRETS_MOUNT_POINT}'!  Aborting build!"
+        fi
+    fi
+
+    # don't pollute the global namespace
+    unset SECRETS_MOUNT_POINT BUILDKITE_TOKEN_PATH BUILDKITE_TOKEN AGENT_PRIVATE_KEY_PATH ADHOC_PAIR
+}
+
+# No matter how we exit, make sure we cleanup our secrets
+trap "cleanup_secrets" EXIT
+
+# Set this to wherever your private key lives
+AGENT_PRIVATE_KEY_PATH="${SECRETS_MOUNT_POINT}/agent.key"
+AGENT_PUBLIC_KEY_PATH="${SECRETS_MOUNT_POINT}/agent.pub"
+if [[ ! -f "${AGENT_PRIVATE_KEY_PATH}" ]]; then
+    die "Unable to open agent private key path '${AGENT_PRIVATE_KEY_PATH}'!  Make sure your agent has this file deployed within it!"
+else
+    if ! openssl rsa -inform PEM -in "${AGENT_PRIVATE_KEY_PATH}" -noout 2>/dev/null; then
+        die "Secret private key path '${AGENT_PRIVATE_KEY_PATH}' is not a valid private RSA key!"
     fi
 fi
-if [[ ! -f "${PUBLIC_KEY_PATH}" ]]; then
-    die "Unable to open agent public key path '${PUBLIC_KEY_PATH}'!  Make sure your agent has this file deployed within it!"
+if [[ ! -f "${AGENT_PUBLIC_KEY_PATH}" ]]; then
+    die "Unable to open agent public key path '${AGENT_PUBLIC_KEY_PATH}'!  Make sure your agent has this file deployed within it!"
 else
-    if ! openssl rsa -inform PEM -pubin -in "${PUBLIC_KEY_PATH}" -noout 2>/dev/null; then
-        die "Secret public key path '${PUBLIC_KEY_PATH}' is not a valid public RSA key!"
+    if ! openssl rsa -inform PEM -pubin -in "${AGENT_PUBLIC_KEY_PATH}" -noout 2>/dev/null; then
+        die "Secret public key path '${AGENT_PUBLIC_KEY_PATH}' is not a valid public RSA key!"
     fi
 fi
 
@@ -78,8 +111,8 @@ fi
 function set_cryptic_privileged() {
     # The first thing we do is export a base64-encoded form of the keys for later consumption by the cryptic plugin
     echo "Privileged build detected; unlocking private key"
-    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PRIVATE_KEY_SECRET="$(base64enc < "${PRIVATE_KEY_PATH}")"
-    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PUBLIC_KEY_SECRET="$(base64enc < "${PUBLIC_KEY_PATH}")"
+    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PRIVATE_KEY_SECRET="$(base64enc < "${AGENT_PRIVATE_KEY_PATH}")"
+    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PUBLIC_KEY_SECRET="$(base64enc < "${AGENT_PUBLIC_KEY_PATH}")"
     export BUILDKITE_PLUGIN_CRYPTIC_PRIVILEGED=true
 
     # The next thing we do is search for `CRYPTIC_ADHOC_SECRET_*` variables and decrypt them.
@@ -91,13 +124,14 @@ function set_cryptic_privileged() {
 
         # No matter what happens, this file dies when we leave
         local TEMP_KEYFILE=$(mktemp)
+        OLD_TRAP="$(trap -p EXIT)"
         trap "rm -f ${TEMP_KEYFILE}" EXIT
 
         # Use `readarray` to split our combined key/value envvar
         readarray -d';' -t ADHOC_PAIR <<<"${!LONG_ADHOC_NAME}"
 
         # Take the key, decrypt it with our RSA private key
-        base64dec <<<"${ADHOC_PAIR[0]}" | openssl rsautl -decrypt -inkey "${PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"
+        base64dec <<<"${ADHOC_PAIR[0]}" | openssl rsautl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"
 
         # Make sure the AES key is the right length
         if [[ $(wc -c <"${TEMP_KEYFILE}") != "128" ]]; then
@@ -107,8 +141,8 @@ function set_cryptic_privileged() {
         export "${EXPORTED_NAME}"="$(base64dec <<<"${ADHOC_PAIR[1]}" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -pass "file:${TEMP_KEYFILE}")"
 
         # Clean up our keyfile and our trap
-        shred -u "${TEMP_KEYFILE}"
-        trap - EXIT
+        secure_delete "${TEMP_KEYFILE}"
+        eval "${OLD_TRAP}"
         unset ADHOC_PAIR
     done
 }
@@ -126,27 +160,15 @@ if [[ "${BUILDKITE_JOB_ID}" == "${BUILDKITE_INITIAL_JOB_ID}" ]]; then
 elif [[ -v "BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET" ]]; then
     # Decode the base64-encoded signature and dump it to a file
     SIGNATURE_FILE="$(mktemp)"
+    OLD_TRAP="$(trap -p EXIT)"
     trap "rm -f ${SIGNATURE_FILE}" EXIT
     openssl base64 -d -A <<<"${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" > "${SIGNATURE_FILE}"
 
     # Verify that the signature is valid; if it is, then unlock the keys!
-    if openssl dgst -sha256 -verify "${PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" <<<"${BUILDKITE_INITIAL_JOB_ID}"; then
+    if openssl dgst -sha256 -verify "${AGENT_PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" <<<"${BUILDKITE_INITIAL_JOB_ID}"; then
         set_cryptic_privileged
     fi
 
     rm -f "${SIGNATURE_FILE}"
-    trap - EXIT
+    eval "${OLD_TRAP}"
 fi
-
-
-## Cleanup: Deny access to secrets to future pipeline steps by either unmounting `/secrets`
-#  or just deleting the files inside, if that doesn't work.  If neither work, we abort the build.
-if ! umount "${SECRETS_MOUNT_POINT}" 2>/dev/null; then
-    if ! rm -rf "${SECRETS_MOUNT_POINT}"; then
-        die "Unable to unmount secrets at '${SECRETS_MOUNT_POINT}'!  Aborting build!"
-    fi
-fi
-
-# don't pollute the global namespace
-unset SECRETS_MOUNT_POINT BUILDKITE_TOKEN_PATH BUILDKITE_TOKEN PRIVATE_KEY_PATH ADHOC_PAIR
-

--- a/linux-sandbox.jl/.gitignore
+++ b/linux-sandbox.jl/.gitignore
@@ -1,2 +1,2 @@
-# Ignore config.toml, as that's intended to be a 
+# Ignore config.toml, as that's intended to be a local customization
 config.toml

--- a/linux-sandbox.jl/config.toml.example
+++ b/linux-sandbox.jl/config.toml.example
@@ -6,8 +6,9 @@ num_agents=4
 
 # We can add arbitrary tags here
 [default.tags]
-foo=bar
-baz=qux
+"sandbox.jl"="true"
+foo="bar"
+baz="qux"
 
 
 # We can have multiple worker groups, these will all get a rootless docker instance
@@ -16,3 +17,6 @@ baz=qux
 queues="default,docker"
 start_rootless_docker=true
 num_agents=2
+
+[docker-enabled.tags]
+"sandbox.jl"="true"

--- a/macos-seatbelt/.gitignore
+++ b/macos-seatbelt/.gitignore
@@ -1,0 +1,2 @@
+# Ignore config.toml, as that's intended to be a local customization
+config.toml

--- a/macos-seatbelt/Artifacts.toml
+++ b/macos-seatbelt/Artifacts.toml
@@ -1,0 +1,19 @@
+[[buildkite-agent]]
+arch = "x86_64"
+git-tree-sha1 = "1dea9726c236c94998d86fb7ebedcc788a9e8537"
+os = "macos"
+lazy = true
+
+    [[buildkite-agent.download]]
+    sha256 = "19f108798308a98dcdddb750faea1f8fa8dc832501fa46757ca4b462b9eb58a0"
+    url = "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-amd64-3.33.3.tar.gz"
+
+[[buildkite-agent]]
+arch = "aarch64"
+git-tree-sha1 = "864c85c068102fe7819f77da78caf57aa77ce37d"
+os = "macos"
+lazy = true
+
+    [[buildkite-agent.download]]
+    sha256 = "1f7ad047f264750fb4b98e9cb7a439a768496358b544641da904913800d035c8"
+    url = "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-arm64-3.33.3.tar.gz"

--- a/macos-seatbelt/MacOSSandboxConfig.jl
+++ b/macos-seatbelt/MacOSSandboxConfig.jl
@@ -1,0 +1,110 @@
+abstract type SandboxResource; end
+SandboxResource(res::SandboxResource) = res
+
+struct SandboxPath <: SandboxResource
+    path::String
+end
+SandboxResource(path::AbstractString) = SandboxPath(String(path))
+Base.print(io::IO, res::SandboxPath) = print(io, "(path \"$(res.path)\")")
+
+struct SandboxSubpath <: SandboxResource
+    path::String
+end
+Base.print(io::IO, res::SandboxSubpath) = print(io, "(subpath \"$(res.path)\")")
+
+struct SandboxRegex <: SandboxResource
+    path::String
+end
+SandboxResource(path::Regex) = SandboxRegex(path.pattern)
+Base.print(io::IO, res::SandboxRegex) = print(io, "(regex #\"$(res.path)\")")
+
+struct SandboxSyscall <: SandboxResource
+    name::String
+end
+Base.print(io::IO, res::SandboxSyscall) = print(io, "(syscall-number $(res.name))")
+
+
+
+abstract type SandboxRule; end
+struct SandboxGlobalRule <: SandboxRule
+    name::String
+    mode::String
+end
+SandboxRule(name::AbstractString, mode::AbstractString = "allow") = SandboxGlobalRule(String(name), String(mode))
+Base.print(io::IO, rule::SandboxGlobalRule) = print(io, "($(rule.mode) $(rule.name))")
+
+struct SandboxScopedRule <: SandboxRule
+    name::String
+    resources::Vector{<:SandboxResource}
+    mode::String
+end
+SandboxRule(name::AbstractString, scopes::Vector{<:SandboxResource}, mode::AbstractString = "allow") = SandboxScopedRule(String(name), scopes, String(mode))
+SandboxRule(name::AbstractString, scopes::Vector, mode::AbstractString = "allow") = SandboxRule(String(name), SandboxResource.(scopes), String(mode))
+function Base.print(io::IO, rule::SandboxScopedRule)
+    println(io, "($(rule.mode) $(rule.name)")
+    for resource in rule.resources
+        println(io, "    $(resource)")
+    end
+    println(io, ")")
+end
+
+
+struct MacOSSandboxConfig
+    # Usually something like `"bsd.sb"`
+    parent_config::Union{Nothing,String}
+
+    # List of actions that should be allowed
+    rules::Vector{<:SandboxRule}
+
+    # Whether we should try getting debug output (doesn't work on modern macOS versions)
+    debug::Bool
+
+    function MacOSSandboxConfig(;rules::Vector{<:SandboxRule} = SandboxRule[],
+                                 parent_config::Union{Nothing,String} = "bsd.sb",
+                                 debug::Bool = true,
+                                )
+        return new(parent_config, rules, debug)
+    end
+end
+
+function generate_sandbox_config(io::IO, config::MacOSSandboxConfig)
+    # First, print out the header:
+    print(io, """
+    (version 1)
+    (deny default)
+    """)
+
+    if config.debug
+        println(io, "(debug deny)")
+    end
+
+    # Inherit from something like `bsd.sb`
+    if config.parent_config !== nothing
+        println(io, "(import \"$(config.parent_config)\")")
+    end
+
+    # Add all rules that are not path-based
+    for rule in config.rules
+        println(io, rule)
+    end
+end
+
+function with_sandbox(f::Function, sandbox_generator::Function, args...; kwargs...)
+    mktempdir() do dir
+        sb_path = joinpath(dir, "macos_sandbox.sb")
+        open(sb_path, write=true) do io
+            sandbox_generator(io, args...; kwargs...)
+        end
+        f(sb_path)
+    end
+end
+
+function dirname_chain(path::AbstractString)
+    dirnames = AbstractString[]
+    path = realpath(path)
+    while dirname(path) != path
+        path = dirname(path)
+        push!(dirnames, path)
+    end
+    return dirnames
+end

--- a/macos-seatbelt/Manifest.toml
+++ b/macos-seatbelt/Manifest.toml
@@ -1,0 +1,123 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.0"
+manifest_format = "2.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.1.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/macos-seatbelt/Project.toml
+++ b/macos-seatbelt/Project.toml
@@ -1,0 +1,5 @@
+uuid = "a66863c6-20e8-4ff4-8a62-49f30b1f605e"
+
+[deps]
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -1,0 +1,406 @@
+#!/usr/bin/env julia
+using LazyArtifacts
+
+include("../common/buildkite_config.jl")
+include("MacOSSandboxConfig.jl")
+
+function generate_buildkite_sandbox(io::IO, workspaces::Vector{String}, temp_dir::String)
+    # We'll generate here a SandboxConfig that 
+    config = MacOSSandboxConfig(;
+        rules = vcat(
+            # First, global rules that are not scoped in any way
+            SandboxRule.([
+                # These are foundational capabilities, and should potentially
+                # be enabled for _all_ sandboxed processes?
+                "process-fork", "process-info*", "process-codesigning-status*",
+                "signal", "mach-lookup", "sysctl-read",
+
+                # Running Julia's test suite requires IPC/shared memory mechanisms as well
+                "ipc-posix-sem", "ipc-sysv-shm", "ipc-posix-shm",
+
+                # Calling `getcwd()` on a non-existant file path returns `EACCES` instead of `ENOENT`
+                # unless we give unrestricted `fcntl()` permissions.
+                "system-fsctl",
+
+                # For some reason, `access()` requires `process-exec` globally.
+                # I don't know why this is, and Apple's own scripts have a giant shrug
+                # in `/usr/share/sandbox/com.apple.smbd.sb` about this
+                "process-exec",
+
+                # We require network access
+                "network-bind", "network-outbound", "network-inbound", "system-socket",
+            ]),
+
+            SandboxRule("file-read*", [
+                # Provide read-only access to the majority of the system, (but NOT things like `/Users` or `/tmp`)
+                SandboxSubpath("/Applications"),
+                SandboxSubpath("/Library"),
+                SandboxSubpath("/System"),
+                SandboxSubpath("/bin"),
+                SandboxSubpath("/opt"),
+                SandboxSubpath("/private/etc"),
+                SandboxSubpath("/private/var"),
+                SandboxSubpath("/sbin"),
+                SandboxSubpath("/usr"),
+                SandboxSubpath("/var"),
+
+                # Specifically, allow read-only access to the entire parental chain of the workspace,
+                # and the temporary directory.  Note that these are not recursive includes, but rather
+                # precisely these directories
+                vcat(dirname_chain.(workspaces)...)...,
+                dirname_chain(temp_dir)...,
+
+                # Allow reading of the buildkite agent, and our hooks directory
+                SandboxSubpath(artifact"buildkite-agent"),
+                SandboxSubpath(joinpath(dirname(@__DIR__), "hooks")),
+
+                # Allow reading of user preferences and keychains
+                SandboxSubpath(joinpath(homedir(), "Library", "Preferences")),
+
+                # Also a few symlinks:
+                "/tmp",
+                "/etc",
+            ]),
+
+            # Provide read-write access to a more restricted set of files
+            SandboxRule("file*", [
+                # Allow control over TTY devices
+                r"/dev/tty.*",
+                "/dev/ptmx",
+                "/private/var/run/utmpx",
+
+                # Allow full control over the workspaces
+                SandboxSubpath.(workspaces)...,
+
+                # Allow reading/writing to the temporary directory
+                SandboxSubpath(temp_dir),
+
+                # Keychain access requires R/W access to a path in /private/var/folders whose path name is difficult to know beforehand
+                SandboxSubpath("/private/var/folders"),
+            ]),
+        )
+    )
+
+    # Write the config out to the provided IO object
+    generate_sandbox_config(io, config)
+    return nothing
+end
+
+function build_sandbox_env(temp_path::String, cache_path::String;
+                           agent_token_path::String = joinpath(dirname(@__DIR__), "secrets", "buildkite-agent-token"),)
+    paths = [
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/usr/bin",
+        "/usr/sbin",
+        "/bin",
+        "/sbin",
+    ]
+    if Sys.ARCH == :aarch64
+        if isdir("/opt/homebrew/Cellar")
+            pushfirst!(paths, "/opt/homebrew/sbin")
+            pushfirst!(paths, "/opt/homebrew/bin")
+        end
+    end
+    return Dict(
+        "TMPDIR" => joinpath(temp_path, "tmp"),
+        "HOME" => joinpath(temp_path, "home"),
+        "BUILDKITE_BIN_PATH" => artifact"buildkite-agent",
+        "BUILDKITE_PLUGIN_JULIA_CACHE_DIR" => cache_path,
+        "BUILDKITE_AGENT_TOKEN" => String(chomp(String(read(agent_token_path)))),
+        "PATH" => join(paths, ":"),
+        "TERM" => "screen",
+    )
+end
+
+function host_paths_to_create(temp_path, cache_path)
+    return String[
+        joinpath(temp_path, "tmp"),
+        joinpath(temp_path, "home"),
+        joinpath(cache_path, "build"),
+    ]
+end
+
+function host_paths_to_cleanup(temp_path, cache_path)
+    return String[
+        temp_path,
+        joinpath(cache_path, "build"),
+    ]
+end
+
+function force_delete(path)
+    Base.Filesystem.prepare_for_deletion(path)
+    rm(path; force=true, recursive=true)
+end
+
+default_agent_name(brg) = string(brg.name, "-", gethostname(), ".0")
+
+function sandbox_setup(f::Function, brg::BuildkiteRunnerGroup;
+                       agent_name::String = default_agent_name(brg),
+                       cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
+                       temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name))
+    # Initial cleanup and creation
+    force_delete.(host_paths_to_cleanup(temp_path, cache_path))
+    mkpath.(host_paths_to_create(temp_path, cache_path))
+    sandbox_env = build_sandbox_env(temp_path, cache_path)
+
+    try
+        # Prepare secrets by copying them in
+        secrets_src_path = joinpath(dirname(@__DIR__), "secrets")
+        secrets_dst_path = joinpath(cache_path, "secrets")
+        cp(secrets_src_path, secrets_dst_path; force=true)
+
+        cd(joinpath(cache_path, "build")) do
+            with_sandbox(generate_buildkite_sandbox, [cache_path], temp_path) do sb_path
+                if brg.verbose
+                    run(`cat $(sb_path)`)
+                    println()
+                    println()
+                end
+                f(sb_path, sandbox_env)
+            end
+        end
+    finally
+        force_delete.(host_paths_to_cleanup(temp_path, cache_path))
+    end       
+end
+
+function debug_shell(brg::BuildkiteRunnerGroup; kwargs...)
+    mktempdir() do workspace
+        sandbox_setup(brg; kwargs...) do sb_path, sandbox_env
+            run(setenv(`sandbox-exec -f $(sb_path) /bin/bash`, sandbox_env))
+        end
+    end
+end
+
+function run_buildkite_agent(brg::BuildkiteRunnerGroup;
+                             agent_name::String = default_agent_name(brg),
+                             cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
+                             kwargs...)
+    sandbox_setup(brg; agent_name, cache_path, kwargs...) do sb_path, sandbox_env
+        agent_path = artifact"buildkite-agent/buildkite-agent"
+        hooks_path = joinpath(dirname(@__DIR__), "hooks")
+
+        tags_with_queues = ["$tag=$value" for (tag, value) in brg.tags]
+        append!(tags_with_queues, ["queue=$(queue)" for queue in brg.queues])
+
+        agent_cmd = ```$(agent_path) start
+            --disconnect-after-job
+            --hooks-path=$(hooks_path)
+            --build-path=$(cache_path)/build
+            --experiment=git-mirrors,output-redactor
+            --git-mirrors-path=$(cache_path)/repos
+            --tags=$(join(tags_with_queues, ","))
+            --name=$(agent_name)
+        ```
+        run(setenv(`sandbox-exec -f $(sb_path) $(agent_cmd)`, sandbox_env))
+    end
+end
+
+struct LaunchctlConfig
+    label::String
+    target::Vector{String}
+
+    env::Dict{String,String}
+    cwd::Union{String,Nothing}
+    logpath::Union{String,Nothing}
+    keepalive::Union{Bool,Nothing}
+
+    function LaunchctlConfig(label, target; env = Dict{String,String}(), cwd = nothing, logpath = nothing, keepalive = true)
+        return new(label, target, env, cwd, logpath, keepalive)
+    end
+end
+
+function write(io::IO, config::LaunchctlConfig)
+    println(io, """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0"><dict>
+    """)
+
+    # Job label, e.g. "org.julialang.buildkite.solstice-default.0"
+    println(io, """
+        <key>Label</key>
+        <string>$(config.label)</string>
+    """)
+
+    # Target process to launch
+    print(io, """
+        <key>ProgramArguments</key>
+            <array>
+    """)
+    for word in config.target
+        println(io, "            <string>$(word)</string>")
+    end
+    println(io, """
+            </array>
+    """)
+
+    # If we've been asked to print a keepalive
+    if config.keepalive !== nothing
+        println(io, """
+            <key>KeepAlive</key>
+            <$(config.keepalive) />
+        """)
+    end
+
+    if config.cwd !== nothing
+        println(io, """
+            <key>WorkingDirectory</key>
+            <string>$(config.cwd)</string>
+        """)
+    end
+
+    if config.logpath !== nothing
+        println(io, """
+            <key>StandardOutPath</key>
+            <string>$(config.logpath)</string>
+            <key>StandardErrorPath</key>
+            <string>$(config.logpath)</string>
+        """)
+    end
+
+    # Write out environment variables path
+    print(io, """
+        <key>EnvironmentVariables</key>
+        <dict>
+    """)
+    for (k, v) in config.env
+        println(io, """
+                <key>$(k)</key>
+                <string>$(v)</string>
+        """)
+    end
+    println(io, """
+        </dict>
+    </dict></plist>
+    """)
+end
+
+function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
+                                   agent_name::String = default_agent_name(brg),
+                                   cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
+                                   temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name),
+                                   kwargs...)
+    # Output wrapper scripts, sandbox definitions, etc... into this directory
+    wrapper_dir = joinpath(cache_path, "wrappers")
+    force_delete(wrapper_dir)
+    mkpath(wrapper_dir)
+    mkpath.(host_paths_to_create(temp_path, cache_path))
+
+    # First, create sandbox definition
+    sb_path = joinpath(wrapper_dir, "sandbox.sb")
+    open(sb_path, write=true) do sb_io
+        generate_buildkite_sandbox(sb_io, [cache_path], temp_path)
+    end
+
+    # Collect relevant information for wrapper script
+    agent_path = artifact"buildkite-agent/buildkite-agent"
+    hooks_path = joinpath(dirname(@__DIR__), "hooks")
+    tags_with_queues = ["$tag=$value" for (tag, value) in brg.tags]
+    append!(tags_with_queues, ["queue=$(queue)" for queue in brg.queues])
+
+    # Create setup/teardown wrapper script
+    wrapper_path = joinpath(wrapper_dir, "wrapper.sh")
+    secrets_src_path = joinpath(dirname(@__DIR__), "secrets")
+    secrets_dst_path = joinpath(cache_path, "secrets")
+    open(wrapper_path, write=true) do w_io
+        print(w_io, """
+        #!/bin/bash
+
+        # Cleanup host paths to protect against stale state leaking
+        """)
+
+        for path in host_paths_to_cleanup(temp_path, cache_path)
+            println(w_io, "rm -rf $(path)")
+        end
+
+        print(w_io, """
+        # Create host paths that must exist
+        """)
+        for path in host_paths_to_create(temp_path, cache_path)
+            println(w_io, "mkdir -p $(path)")
+        end
+
+        println(w_io, """
+        # Copy secrets into cache directory, which will be deleted by agent environment hook
+        rm -rf $(secrets_dst_path)
+        cp -Ra $(secrets_src_path) $(secrets_dst_path)
+
+        # Invoke agent inside of sandbox
+        sandbox-exec -f $(sb_path) $(agent_path) start \\
+            --disconnect-after-job \\
+            --hooks-path=$(hooks_path) \\
+            --build-path=$(cache_path)/build \\
+            --experiment=git-mirrors,output-redactor \\
+            --git-mirrors-path=$(cache_path)/repos \\
+            --tags=$(join(tags_with_queues, ",")) \\
+            --name=$(agent_name)
+        """)
+
+        print(w_io, """
+        # Cleanup host paths
+        """)
+        for path in host_paths_to_cleanup(temp_path, cache_path)
+            println(w_io, "rm -rf $(path)")
+        end
+    end
+
+    # Create launchctl script
+    lctl_config = LaunchctlConfig(
+        "org.julialang.buildkite.$(agent_name)",
+        ["/bin/sh", wrapper_path];
+        env = build_sandbox_env(temp_path, cache_path),
+        cwd = joinpath(cache_path, "build"),
+        logpath = joinpath(cache_path, "agent.log"),
+        keepalive = true,
+    )
+    write(io, lctl_config)
+end
+
+function default_plist_path(agent_name::String)
+    return joinpath(expanduser("~"), "Library", "LaunchAgents", "org.julialang.buildkite.$(agent_name).plist")
+end
+function generate_launchctl_script(brg::BuildkiteRunnerGroup;
+                                   agent_name::String = default_agent_name(brg),
+                                   plist_path::String = default_plist_path(agent_name),
+                                   kwargs...)
+    mkpath(dirname(plist_path))
+    open(plist_path, write=true) do io
+        generate_launchctl_script(io, brg; kwargs...)
+    end
+    return plist_path
+end
+
+function launch_launchctl_services(brgs::Vector{BuildkiteRunnerGroup})
+    for brg in brgs
+        plist_path = default_plist_path(default_agent_name(brg))
+        # Force unload, so that if we already have one started, it can be replaced
+        run(ignorestatus(`launchctl unload -w $(plist_path)`))
+        run(`launchctl load -w $(plist_path)`)
+    end
+end
+
+function stop_launchctl_services(brgs::Vector{BuildkiteRunnerGroup})
+    for brg in brgs
+        plist_path = default_plist_path(default_agent_name(brg))
+        run(ignorestatus(`launchctl unload -w $(plist_path)`))
+    end
+end
+
+function clear_launchctl_services()
+    services = filter(readdir("/Library/LaunchDaemons")) do f
+        return startswith(f, "org.julialang.buildkite") && endswith(f, ".plist")
+    end
+    for service in services
+        plist_path = joinpath("/Library", "LaunchDaemons", service)
+        run(ignorestatus(`launchctl unload -w $(plist_path)`))
+        rm(plist_path; force=true)
+    end
+
+    for f in readdir(expanduser("~/.config/systemd/user"); join=true)
+        if startswith(basename(f), "buildkite-sandbox-")
+            rm(f)
+        end
+    end
+end

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -5,7 +5,8 @@ include("../common/buildkite_config.jl")
 include("MacOSSandboxConfig.jl")
 
 function generate_buildkite_sandbox(io::IO, workspaces::Vector{String}, temp_dir::String)
-    # We'll generate here a SandboxConfig that 
+    # We'll generate here a MacOSSandboxConfig that allows us to run builds within a build prefix,
+    # but not write to the rest of the system, nor read sensitive files
     config = MacOSSandboxConfig(;
         rules = vcat(
             # First, global rules that are not scoped in any way
@@ -32,7 +33,7 @@ function generate_buildkite_sandbox(io::IO, workspaces::Vector{String}, temp_dir
             ]),
 
             SandboxRule("file-read*", [
-                # Provide read-only access to the majority of the system, (but NOT things like `/Users` or `/tmp`)
+                # Provide read-only access to the majority of the system, but NOT `/Users`
                 SandboxSubpath("/Applications"),
                 SandboxSubpath("/Library"),
                 SandboxSubpath("/System"),

--- a/macos-seatbelt/config.toml.example
+++ b/macos-seatbelt/config.toml.example
@@ -1,0 +1,3 @@
+[default]
+queues="julia"
+num_agents=1

--- a/macos-seatbelt/debug_shell.jl
+++ b/macos-seatbelt/debug_shell.jl
@@ -1,0 +1,10 @@
+#!/usr/bin/env julia
+include("common.jl")
+
+# Load the group name that we're going to impersonate
+configs = read_configs()
+group_name = get(ARGS, 1, configs[1].name)
+config = only(filter(c -> c.name == group_name, configs))
+
+# Run the debug shell
+debug_shell(config)

--- a/macos-seatbelt/launch_agents.jl
+++ b/macos-seatbelt/launch_agents.jl
@@ -1,0 +1,9 @@
+#!/usr/bin/env julia
+include("common.jl")
+
+# Load the group name that we're going to impersonate
+configs = read_configs()
+
+clear_launchctl_services()
+generate_launchctl_script.(configs)
+launch_launchctl_services(configs)

--- a/macos-seatbelt/uninstall_agents.jl
+++ b/macos-seatbelt/uninstall_agents.jl
@@ -1,0 +1,3 @@
+#!/usr/bin/env julia
+include("common.jl")
+clear_launchctl_services()


### PR DESCRIPTION
This PR adds a macOS runner that makes use of the macOS sandbox functionality known as Seatbelt to reduce the harm a malicious CI job could do to one of our machines.  It also allows for secrets management by allowing secrets to be stored in an unreadable location, then having the CI start job copy secrets into a readable location, but having an agent environment hook delete them if the job is not privileged, similar to how the `sandbox.jl` runner unmounts the secrets location.