### PR TITLE
Add `num_cpus` config option

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.6.2"
+julia_version = "1.7.2"
 manifest_format = "2.0"
 
 [[deps.ArgTools]]
@@ -82,9 +82,9 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "de893592a221142f3db370f48290e3a2ef39998f"
+git-tree-sha1 = "d3538e7f8a790dc8903519090857ef8e1283eecd"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.4"
+version = "1.2.5"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -95,7 +95,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.SHA]]
@@ -142,9 +142,9 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[deps.UserNSSandbox_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a3a3f3680b6129c1b34ca5a6b09201afbc7b7805"
+git-tree-sha1 = "c739fca3eca5647c833895362ea3cda5596a249f"
 uuid = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
-version = "2022.1.20+0"
+version = "2022.3.10+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -17,6 +17,10 @@ struct BuildkiteRunnerGroup
     # NOTE: this only works with `linux-sandbox.jl` runners!
     start_rootless_docker::Bool
 
+    # Whether to lock workers to CPUs.  Zero if unused.
+    # NOTE: This only works with `linux-sandbox.jl` runners!
+    num_cpus::Int
+
     # winkvm only: the source image to use for building the agent-specific image
     source_image::String
 
@@ -29,8 +33,9 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
     num_agents = get(config, "num_agents", 1)
     tags = get(config, "tags", Dict{String,String}())
     start_rootless_docker = get(config, "start_rootless_docker", false)
-    verbose = get(config, "verbose", false)
+    num_cpus = get(config, "num_cpus", 0)
     source_image = get(config, "source_image", "")
+    verbose = get(config, "verbose", false)
 
     # Encode some information about this runner
     merge!(tags, extra_tags)
@@ -47,6 +52,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
         queues,
         tags,
         start_rootless_docker,
+        num_cpus,
         source_image,
         verbose,
     )

--- a/common/linux_systemd_config.jl
+++ b/common/linux_systemd_config.jl
@@ -85,8 +85,9 @@ struct SystemdConfig
     #######################################################
     # Execution Hooks
     #######################################################
-    start_hooks::Vector{SystemdTarget}
-    stop_hooks::Vector{SystemdTarget}
+    start_pre_hooks::Vector{SystemdTarget}
+    start_post_hooks::Vector{SystemdTarget}
+    stop_post_hooks::Vector{SystemdTarget}
 end
 
 function SystemdConfig(;exec_start::SystemdTarget,
@@ -100,8 +101,9 @@ function SystemdConfig(;exec_start::SystemdTarget,
                         type = :simple,
                         pid_file = nothing,
                         kill_signal = nothing,
-                        start_hooks::Vector{SystemdTarget} = SystemdTarget[],
-                        stop_hooks::Vector{SystemdTarget} = SystemdTarget[])
+                        start_pre_hooks::Vector{SystemdTarget} = SystemdTarget[],
+                        start_post_hooks::Vector{SystemdTarget} = SystemdTarget[],
+                        stop_post_hooks::Vector{SystemdTarget} = SystemdTarget[])
     nstr(x) = x === nothing ? nothing : string(x)
 
     return SystemdConfig(
@@ -120,8 +122,9 @@ function SystemdConfig(;exec_start::SystemdTarget,
         nstr(kill_signal),
 
         # Execution hooks
-        start_hooks,
-        stop_hooks,
+        start_pre_hooks,
+        start_post_hooks,
+        stop_post_hooks,
     )
 end
 
@@ -147,8 +150,11 @@ function Base.write(io::IO, cfg::SystemdConfig)
 
     # What hooks do we need to run before the target?
     println(io, "# Execution hooks and target")
-    for hook in cfg.start_hooks
+    for hook in cfg.start_pre_hooks
         println(io, "ExecStartPre", hook)
+    end
+    for hook in cfg.start_post_hooks
+        println(io, "ExecStartPost", hook)
     end
 
     # The actual target
@@ -160,7 +166,7 @@ function Base.write(io::IO, cfg::SystemdConfig)
     println(io)
 
     # What hooks do we need to run after the target?
-    for hook in cfg.stop_hooks
+    for hook in cfg.stop_post_hooks
         println(io, "ExecStopPost", hook)
     end
     println(io)

--- a/linux-sandbox.jl/cgroup_wrapper.sh
+++ b/linux-sandbox.jl/cgroup_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# The sandbox runner will always mount our own cgroup at this special mountpoint
+echo "$$" > /sys/fs/cgroup/cpuset/self/tasks
+
+# Sub off to the given process
+exec "$@"

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -65,7 +65,7 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
                 cpuset_path = "/sys/fs/cgroup/cpuset/$(first(names))"
                 println(io, """
                     $(join(names, "|")))
-                        $(mk_cgroup_path) $(first(names)) $(Sandbox.getuid()) $(Sandbox.getgid()) $(cpus)
+                        $(mk_cgroup_path) $(first(names)) $(cpus)
                         ;;
                 """)
             end

--- a/linux-sandbox.jl/debug_shell.jl
+++ b/linux-sandbox.jl/debug_shell.jl
@@ -3,6 +3,7 @@ include("common.jl")
 
 # Load the group name that we're going to impersonate
 configs = read_configs()
+check_configs(configs)
 name_pattern = get(ARGS, 1, configs[1].name)
 
 

--- a/linux-sandbox.jl/launch_agents.jl
+++ b/linux-sandbox.jl/launch_agents.jl
@@ -4,6 +4,9 @@ include("common.jl")
 # Load TOML configs
 configs = read_configs()
 
+# Ensure that all our configs are good
+check_configs(configs)
+
 clear_systemd_configs()
 generate_systemd_script.(configs)
 launch_systemd_services(configs)

--- a/linux-sandbox.jl/mk_cgroup.c
+++ b/linux-sandbox.jl/mk_cgroup.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <libgen.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+#define min(x, y)       ((x) < (y) ? (x) : (y))
+
+/* Like assert, but don't go away with optimizations */
+static void _check(int ok, int line) {
+    if (!ok) {
+        fprintf(stderr, "At line %d, ABORTED (%d: %s)!\n", line, errno, strerror(errno));
+        fflush(stdout);
+        fflush(stderr);
+        exit(1);
+    }
+}
+#define check(ok) _check(ok, __LINE__)
+
+/* Make all directories up to the given directory name. */
+static void mkpath(const char * dir) {
+    struct stat sb;
+    if (stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
+        return;
+    }
+    // Otherwise, first make sure our parent exists.  Note that dirname()
+    // clobbers its input, so we copy to a temporary variable first. >:|
+    char dir_dirname[PATH_MAX];
+    strncpy(dir_dirname, dir, PATH_MAX - 1);
+    mkpath(dirname(&dir_dirname[0]));
+
+    // then create our directory
+    int result = mkdir(dir, 0777);
+    check((0 == result));
+}
+
+static int chown_r(const char * path, uid_t uid, gid_t gid) {
+    DIR * dir = opendir(path);
+    if (!dir) {
+        return 1;
+    }
+    check(chown(path, uid, gid) == 0);
+
+    struct dirent *entry;
+    char leaf_path[PATH_MAX];
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+
+        snprintf(leaf_path, sizeof(leaf_path), "%s/%s", path, entry->d_name);
+        check(chown(leaf_path, uid, gid) == 0);
+
+        if (entry->d_type == DT_DIR) {
+            if (chown_r(leaf_path, uid, gid) != 0) {
+                return 1;
+            }
+        }
+    }
+    closedir(dir);
+
+    return 0;
+}
+
+static int verify_cgroup(const char * name, uid_t uid, gid_t gid, const char * cpus) {
+    // First, check if the directory exists:
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s", name);
+    struct stat sb;
+    if (stat(path, &sb) != 0 || !S_ISDIR(sb.st_mode)) {
+        return 1;
+    }
+
+    // Ensure it's owned by the right uid and gid
+    if (sb.st_uid != uid || sb.st_gid != gid) {
+        return 1;
+    }
+
+    // Ensure the assigned cpus are correct
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.cpus", name);
+    int fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        return 1;
+    }
+    char buff[128];
+    int bytes_read = read(fd, buff, sizeof(buff));
+    close(fd);
+    if (bytes_read <= 0) {
+        return 1;
+    }
+    if (strncmp(cpus, buff, min(bytes_read, strlen(cpus))) != 0) {
+        return 1;
+    }
+
+    // Ensure the assigned mems are correct
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.mems", name);
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        return 1;
+    }
+    bytes_read = read(fd, buff, sizeof(buff));
+    close(fd);
+    if (bytes_read <= 0) {
+        return 1;
+    }
+
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/cpuset.mems");
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        return 1;
+    }
+    char true_mems[128];
+    bytes_read = read(fd, true_mems, sizeof(true_mems));
+    if (bytes_read <= 0) {
+        return 1;
+    }
+    if (strncmp(true_mems, buff, bytes_read) != 0) {
+        return 1;
+    }
+
+    // If all of those tests passed, the cgroup is setup correctly!
+    return 0;
+}
+
+int main(int argc, char * argv[]) {
+    if( argc < 5 ) {
+        fprintf(stderr, "Usage: mk_cgroup <name> <uid> <gid> <cpus>\n");
+        return 1;
+    }
+    const char * name = argv[1];
+    uid_t uid = atoi(argv[2]);
+    gid_t gid = atoi(argv[3]);
+    const char * cpus = argv[4];
+
+    if (verify_cgroup(name, uid, gid, cpus) == 0) {
+        // We can exit out immediately without doing anything
+        return 0;
+    }
+
+    // First, create the cpuset
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s", name);
+    mkpath(path);
+
+    // Chown it (recursively) to the appropriate user
+    check(chown_r(path, uid, gid) == 0);
+
+    // Next, assign the appropriate cpus to it
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.cpus", name);
+    int fd = open(path, O_WRONLY);
+    check(fd != -1);
+    check(write(fd, cpus, strlen(cpus)) == strlen(cpus));
+    check(close(fd) == 0);
+
+    // Copy from the global mems
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/cpuset.mems");
+    fd = open(path, O_RDONLY);
+    check(fd != -1);
+    char mems_contents[128];
+    int mems_contents_len = read(fd, mems_contents, sizeof(mems_contents));
+    check(mems_contents_len > 0);
+    check(mems_contents_len <= sizeof(mems_contents));
+    check(close(fd) == 0);
+
+    // Into our new mems
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.mems", name);
+    fd = open(path, O_WRONLY);
+    check(fd != -1);
+    check(write(fd, mems_contents, mems_contents_len) == mems_contents_len);
+    check(close(fd) == 0);
+
+    // Verify to ensure that everything went well
+    check(verify_cgroup(name, uid, gid, cpus) == 0);
+    return 0;
+ }

--- a/linux-sandbox.jl/mk_cgroup.c
+++ b/linux-sandbox.jl/mk_cgroup.c
@@ -128,14 +128,14 @@ static int verify_cgroup(const char * name, uid_t uid, gid_t gid, const char * c
 }
 
 int main(int argc, char * argv[]) {
-    if( argc < 5 ) {
-        fprintf(stderr, "Usage: mk_cgroup <name> <uid> <gid> <cpus>\n");
+    if( argc < 3 ) {
+        fprintf(stderr, "Usage: mk_cgroup <name> <cpus>\n");
         return 1;
     }
     const char * name = argv[1];
-    uid_t uid = atoi(argv[2]);
-    gid_t gid = atoi(argv[3]);
-    const char * cpus = argv[4];
+    const char * cpus = argv[2];
+    uid_t uid = getuid();
+    gid_t gid = getgid();
 
     if (verify_cgroup(name, uid, gid, cpus) == 0) {
         // We can exit out immediately without doing anything

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -238,6 +238,7 @@ function run_buildkite_agent(brg::BuildkiteRunnerGroup;
             --build-path=$(cache_path)/build
             --experiment=git-mirrors,output-redactor
             --git-mirrors-path=$(cache_path)/repos
+            --git-fetch-flags="-v --prune --tags"
             --tags=$(join(tags_with_queues, ","))
             --name=$(agent_name)
         ```

--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -17,6 +17,9 @@ $bk_config="C:\buildkite-agent\buildkite-agent.cfg"
 
 Add-Content -Path "$bk_config" -Value "shell=`"bash.exe -c`""
 
+# Fetch git tags as well
+Add-Content -Path "$bk_config" -Value "git-fetch-flags=`"-v --prune --tags`""
+
 # Set environment variables to point some important buildkite agent storage to Z:
 New-Item -Path "Z:\" -Name "cache" -ItemType "directory"
 [Environment]::SetEnvironmentVariable("BUILDKITE_PLUGIN_JULIA_CACHE_DIR", "Z:\cache", [System.EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
This builds cgroups with pinned cores, for better worker isolation (and
to teach `rr` to not always pin to the same first few CPUs).  This is
implemented by creating wrapper scripts that generate cgroups and pin
agents to specific cores.  This has the added benefit of completely
disallowing a poorly-behaved worker process from taking over other
worker's cores.