### PR TITLE
Add `stop_timeout` and apply it to 120min

### DIFF
--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -347,6 +347,8 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::
             env=Dict(k => v for (k,v) in split.(c.env, Ref("="))),
             restart=SystemdRestartConfig(),
             start_timeout="1min",
+            stop_timeout="120min",
+            kill_mode="mixed",
             start_pre_hooks,
             exec_start=SystemdTarget(join(c.exec, " ")),
             stop_post_hooks,


### PR DESCRIPTION
This will allow us to gracefully stop our buildkite-agent processes,
instead of brutally murdering them and interrupting jobs every time we
have a new configuration change.  This will send `SIGTERM` to the
sandbox process, and then wait up to two hours before sending a
`SIGKILL` to the entire process group.

For this to actually work, we need to wait until sandbox responds to
signals properly, which is pending this PR [0] getting merged.

[0] https://github.com/staticfloat/Sandbox.jl/pull/90