### PR TITLE
Add `tempdir` to allow overriding `TMPDIR` on a per-BRG basis

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -24,6 +24,9 @@ struct BuildkiteRunnerGroup
     # winkvm only: the source image to use for building the agent-specific image
     source_image::String
 
+    # A per-brg override for what `tempdir()` should return
+    tempdir_path::Union{String,Nothing}
+
     # Whether this runner should be run in verbose mode
     verbose::Bool
 end
@@ -35,6 +38,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
     start_rootless_docker = get(config, "start_rootless_docker", false)
     num_cpus = get(config, "num_cpus", 0)
     source_image = get(config, "source_image", "")
+    tempdir_path = get(config, "tempdir", nothing)
     verbose = get(config, "verbose", false)
 
     # Encode some information about this runner
@@ -63,6 +67,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
         start_rootless_docker,
         num_cpus,
         source_image,
+        tempdir_path,
         verbose,
     )
 end
@@ -81,4 +86,8 @@ function get_config_gitsha()
     LibGit2.with(GitRepo(dirname(@__DIR__))) do repo
         return string(LibGit2.GitHash(LibGit2.head(repo)))
     end
+end
+
+function Base.tempdir(brg::BuildkiteRunnerGroup)
+    return something(brg.tempdir_path, tempdir())
 end

--- a/common/mac_seatbelt_config.jl
+++ b/common/mac_seatbelt_config.jl
@@ -139,6 +139,9 @@ function generate_buildkite_seatbelt_config(io::IO, workspaces::Vector{String}, 
                 # in `/usr/share/sandbox/com.apple.smbd.sb` about this
                 "process-exec",
 
+                # When building .dmg's, we need to talk to IOKit
+                "iokit-open-user-client",
+
                 # We require network access
                 "network-bind", "network-outbound", "network-inbound", "system-socket",
             ]),
@@ -183,6 +186,11 @@ function generate_buildkite_seatbelt_config(io::IO, workspaces::Vector{String}, 
                 "/dev/ptmx",
                 "/private/var/run/utmpx",
                 SeatbeltSubpath("/dev/fd"),
+
+                # These rules necessary for creating dmg images
+                # Allow write access to `/dev/rdiskN` where N is 2 or higher
+                r"/dev/rdisk[2-9]+s[0-9]+",
+                r"/Volumes/Julia.*",
 
                 # Allow full control over the workspaces
                 SeatbeltSubpath.(workspaces)...,

--- a/common/mac_seatbelt_config.jl
+++ b/common/mac_seatbelt_config.jl
@@ -131,6 +131,9 @@ function generate_buildkite_seatbelt_config(io::IO, workspaces::Vector{String}, 
                 # unless we give unrestricted `fcntl()` permissions.
                 "system-fsctl",
 
+                # The REPL tests require creating pseudo-tty's
+                "pseudo-tty",
+
                 # For some reason, `access()` requires `process-exec` globally.
                 # I don't know why this is, and Apple's own scripts have a giant shrug
                 # in `/usr/share/sandbox/com.apple.smbd.sb` about this
@@ -146,6 +149,7 @@ function generate_buildkite_seatbelt_config(io::IO, workspaces::Vector{String}, 
                 SeatbeltSubpath("/Library"),
                 SeatbeltSubpath("/System"),
                 SeatbeltSubpath("/bin"),
+                SeatbeltSubpath("/dev"),
                 SeatbeltSubpath("/opt"),
                 SeatbeltSubpath("/private/etc"),
                 SeatbeltSubpath("/private/var"),

--- a/common/mac_seatbelt_config.jl
+++ b/common/mac_seatbelt_config.jl
@@ -168,7 +168,8 @@ function generate_buildkite_seatbelt_config(io::IO, workspaces::Vector{String}, 
                 SeatbeltSubpath(joinpath(dirname(@__DIR__), "hooks")),
 
                 # Allow reading of user preferences and keychains
-                SeatbeltSubpath(joinpath(homedir(), "Library", "Preferences")),
+                # EDIT: I don't think this should be necessary, as we override $HOME
+                #SeatbeltSubpath(joinpath(homedir(), "Library", "Preferences")),
 
                 # Also a few symlinks:
                 "/tmp",

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -137,7 +137,7 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
                        agent_token_path::String = joinpath(dirname(@__DIR__), "secrets", "buildkite-agent-token"),
                        agent_name::String = brg.name,
                        cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
-                       temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name),
+                       temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name),
                        )
     repo_root = dirname(@__DIR__)
 
@@ -348,7 +348,7 @@ const systemd_unit_name_stem = "buildkite-sandbox-"
 function debug_shell(brg::BuildkiteRunnerGroup;
                      agent_name::String = brg.name,
                      cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
-                     temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name))
+                     temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name))
     config = SandboxConfig(brg; agent_name, cache_path, temp_path)
 
     # Initial cleanup and creation

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -7,7 +7,7 @@ include("../common/common.jl")
 function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
                                    agent_name::String = default_agent_name(brg),
                                    cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
-                                   temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name),
+                                   temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name),
                                    kwargs...)
     # Output wrapper scripts, sandbox definitions, etc... into this directory
     wrapper_dir = joinpath(cache_path, "wrappers")
@@ -186,7 +186,7 @@ default_agent_name(brg) = string(brg.name, "-", gethostname(), ".0")
 function seatbelt_setup(f::Function, brg::BuildkiteRunnerGroup;
                        agent_name::String = default_agent_name(brg),
                        cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
-                       temp_path::String = joinpath(tempdir(), "agent-tempdirs", agent_name))
+                       temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name))
     # Initial cleanup and creation
     force_delete.(host_paths_to_cleanup(temp_path, cache_path))
     mkpath.(host_paths_to_create(temp_path, cache_path))

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -116,19 +116,14 @@ function stop_launchctl_services(brgs::Vector{BuildkiteRunnerGroup})
 end
 
 function clear_launchctl_services()
-    services = filter(readdir("/Library/LaunchDaemons")) do f
+    launchctl_dir = dirname(default_plist_path(""))
+    services = filter(readdir(launchctl_dir)) do f
         return startswith(f, "org.julialang.buildkite") && endswith(f, ".plist")
     end
     for service in services
-        plist_path = joinpath("/Library", "LaunchDaemons", service)
+        plist_path = joinpath(launchctl_dir, service)
         run(ignorestatus(`launchctl unload -w $(plist_path)`))
         rm(plist_path; force=true)
-    end
-
-    for f in readdir(expanduser("~/.config/systemd/user"); join=true)
-        if startswith(basename(f), "buildkite-sandbox-")
-            rm(f)
-        end
     end
 end
 

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -160,6 +160,8 @@ function host_paths_to_create(temp_path, cache_path)
     return String[
         joinpath(temp_path, "tmp"),
         joinpath(temp_path, "home"),
+        # This is required by `security list-keychains`
+        joinpath(temp_path, "home", "Library", "Preferences"),
         joinpath(cache_path, "build"),
     ]
 end


### PR DESCRIPTION
Initial usecase: dodging socket pathname limits on macOS.  It turns out
that libuv doesn't support pathnames larger than 108, which is much
smalelr than the `bind()` syscall actually supports.