### PR TITLE
Improve `nproc` shim for macOS

### DIFF
--- a/hooks/environment.d/101_julia_num_cores.sh
+++ b/hooks/environment.d/101_julia_num_cores.sh
@@ -5,9 +5,18 @@
 # another environment hook in your `environment.local.d` directory,
 # which is appropriately `.gitignore`'d to maintain a local config.
 if [[ "$(uname)" == "Darwin" ]]; then
-    function nproc() {
-        sysctl -n "hw.ncpu"
-    }
+    # If we're building on a big.LITTLE architecture, only use the
+    # performance cores
+    if [[ $(sysctl -n hw.nperflevels 2>/dev/null || true) -gt 1 ]]; then
+        function nproc() {
+            sysctl -n "hw.perflevel0.logicalcpu"
+        }
+    else
+        function nproc() {
+            sysctl -n "hw.ncpu"
+        }
+    fi
+    export -f nproc
 fi
 
 export JULIA_CPU_THREADS="$(($(nproc) > 16 ? 16 : $(nproc)))"


### PR DESCRIPTION
This allows us to use only performance cores on big.LITTLE architectures like the Apple M1