### PR TITLE
Add automatic checks for coredump patterning

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.6.3"
+julia_version = "1.7.2"
 manifest_format = "2.0"
 
 [[deps.ArgTools]]
@@ -95,7 +95,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.SHA]]
@@ -103,9 +103,9 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[deps.Sandbox]]
 deps = ["LazyArtifacts", "Libdl", "Preferences", "Random", "SHA", "Scratch", "TOML", "Tar", "Tar_jll", "UserNSSandbox_jll"]
-git-tree-sha1 = "59bbd36ca0f90d5fbf559e7475be8db8523761d9"
+git-tree-sha1 = "6f63cf7ba2dc84f3bd71a7214cc5dca241487c8d"
 uuid = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,4 +6,4 @@ Sandbox = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
-Sandbox = "1.2"
+Sandbox = "1.3"

--- a/common/common.jl
+++ b/common/common.jl
@@ -3,6 +3,7 @@ include("security.jl")
 
 if Sys.islinux()
     include("linux_systemd_config.jl")
+    include("linux_coredump_config.jl")
 end
 if Sys.isapple()
     include("mac_launchctl_config.jl")

--- a/common/linux_coredump_config.jl
+++ b/common/linux_coredump_config.jl
@@ -1,0 +1,81 @@
+function get_coredump_pattern()
+    return strip(String(read("/proc/sys/kernel/core_pattern")))
+end
+
+function ensure_coredump_pattern(pattern::String = "%e-pid%p-sig%s-ts%t.core")
+    if get_coredump_pattern() != pattern
+        @info("Setting coredump pattern, may ask for sudo password...")
+        run(pipeline(`echo "$(strip(pattern))"`, pipeline(`sudo tee /proc/sys/kernel/core_pattern`, devnull)))
+
+        # Ensure that the change was effective
+        if get_coredump_pattern() != pattern
+            error("Unable to set coredump pattern!")
+        end
+    end
+end
+
+
+# Helper methods for testing coredump capabilities
+mutable struct RLimit
+    cur::Int64
+    max::Int64
+end
+function with_coredumps(f::Function)
+    # from /usr/include/sys/resource.h
+    RLIMIT_CORE = 4
+    rlim = Ref(RLimit(0, 0))
+    # Get the current core size limit
+    rc = ccall(:getrlimit, Cint, (Cint, Ref{RLimit}), RLIMIT_CORE, rlim)
+    @assert rc == 0
+    current = rlim[].cur
+    try
+        # Set the new limit to the max
+        rlim[].cur = rlim[].max
+        ccall(:setrlimit, Cint, (Cint, Ref{RLimit}), RLIMIT_CORE, rlim)
+        f()
+    finally
+        # Reset back to the old limit
+        rlim[].cur = current
+        ccall(:setrlimit, Cint, (Cint, Ref{RLimit}), RLIMIT_CORE, rlim)
+    end
+    nothing
+end
+
+function test_coredump_pattern()
+    # Make sure coredump patterns are correct
+    ensure_coredump_pattern()
+
+    # Helper function to run gdb batch commands
+    function gdb(core_path, cmd; julia = first(Base.julia_cmd().exec))
+        run(`gdb -nh $(julia) $(core_path) -batch -ex "$(cmd)"`)
+    end
+
+    mktempdir() do dir; cd(dir) do
+        with_coredumps() do
+            # Trigger a segfault
+            run(ignorestatus(`$(Base.julia_cmd()) -e 'ccall(Ptr{UInt8}(rand(UInt64)), Cint, ())'`))
+
+            # Ensure there is a core file
+            core_file_path = only(readdir(dir))
+
+            # Compress core file
+            compression_time = @elapsed run(`zstd -z -19 -T0 $(core_file_path)`)
+
+            @info("Core file created",
+                path=core_file_path,
+                size=Base.format_bytes(filesize(core_file_path)),
+                compressed_size=Base.format_bytes(filesize("$(core_file_path).zst")),
+                compression_time=compression_time,
+            )
+
+            # Backtrace
+            @info("Backtrace")
+            gdb(core_file_path, "bt")
+            
+            # Memory mapping dump
+            @info("Memory Maps")
+            gdb(core_file_path, "info files")
+        end
+    end; end
+
+end

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -84,6 +84,9 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
         end
         chmod(cg_path, 0o755)
     end
+
+    # Check that we have coredumps configured to write out with the appropriate pattern
+    ensure_coredump_pattern()
 end
 
 function cpu_topology_permutation()


### PR DESCRIPTION
This will give us intelligent names for coredumps that occur during
testing.  We'll use this with improvments to our testing scripts to
automatically dump out useful information and upload full core dumps.