### PR TITLE
Ensure coredump patterns survive a reboot

### DIFF
--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -86,7 +86,7 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
     end
 
     # Check that we have coredumps configured to write out with the appropriate pattern
-    ensure_coredump_pattern()
+    setup_coredumps()
 end
 
 function cpu_topology_permutation()


### PR DESCRIPTION
We need to disable `apport` and ensure that our core dump naming pattern
is listed as a sysctl parameter so it survives reboots.