### PR TITLE
Add `cpu_overlap` so we can flexibly oversubscribe our CPUs

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -21,6 +21,14 @@ struct BuildkiteRunnerGroup
     # NOTE: This only works with `linux-sandbox.jl` runners!
     num_cpus::Int
 
+    # Along with `num_cpus`, we can overlap a few of them in order
+    # to oversubscribe our machine a bit.  Note that an overlap of `1`
+    # will cause _2_ CPUs to be oversubscribed in your set in general,
+    # as the first CPU in our group will overlap with the previous
+    # cpuset, and our last CPU will overlap with the first CPU in the
+    # next cpuset!
+    cpu_overlap::Int
+
     # The platform that this will run as
     platform::Platform
 
@@ -40,6 +48,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
     tags = get(config, "tags", Dict{String,String}())
     start_rootless_docker = get(config, "start_rootless_docker", false)
     num_cpus = get(config, "num_cpus", 0)
+    cpu_overlap = get(config, "cpu_overlap", 0)
     platform = parse(Platform, get(config, "platform", triplet(HostPlatform())))
     source_image = get(config, "source_image", "")
     tempdir_path = get(config, "tempdir", nothing)
@@ -70,6 +79,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
         tags,
         start_rootless_docker,
         num_cpus,
+        cpu_overlap,
         platform,
         source_image,
         tempdir_path,

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -21,7 +21,7 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
     end
 
     # Check that we aren't trying to pin too many cores
-    pinned_cores = sum(brg.num_agents * brg.num_cpus for brg in brgs)
+    pinned_cores = sum(brg.num_agents * (brg.num_cpus - brg.cpu_overlap) for brg in brgs)
     if pinned_cores > Sys.CPU_THREADS
         error("Refusing to attempt to pin agents to more cores than exist!")
     end
@@ -40,7 +40,7 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
                 if brg.num_cpus > 0
                     names = [string(brg.name, "-", get_short_hostname(), ".", agent_idx), unit_name]
                     names_to_cpus[names] = condense_cpu_selection(cpu_permutation[cpu_offset+1:cpu_offset+brg.num_cpus])
-                    cpu_offset += brg.num_cpus
+                    cpu_offset += (brg.num_cpus - brg.cpu_overlap)
                 end
                 agent_idx += 1
             end


### PR DESCRIPTION
We're CPU-pinning our workers away from eachother so that `rr` doesn't
trample a single CPU and so that we don't interfere with eachother that
much, but we should perhaps allow _some_ oversubscription, as we are
leaving a lot of CPU performance on the table right now.

@Keno The main thing I'm worried about is that, due to our CPU pinning, we'll accidentally get two busy `rr` processes pinned over eachother.

The fundamental problem is that we dedicate 16 cores to each worker process (giving us 8 workers per amdci node), but then half of those workers are stuck running Julia bootstrap all the time, and we get pretty low CPU core utilization over time:

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/130920/174393026-bdd5566d-11d4-412d-a96a-e10c4015f7c5.png">

This is my "simple" way of fixing it, while the "complex" way would be to split the worker processes into cpuset-locked workers that have no overlap with eachother and run the Julia tests, and non-cpuset-locked workers that run things like the Julia build and are allowed to trample over eachother.

Do you think I should be okay to just oversubscribe some of our CPUs (never more than 2x oversubscription) and `rr` tests will still be fine?  Or must I go and rearchitect a bunch of pipelines to separate out the workers?