### PR TITLE
Git v2.32+ doesn't like `.gitignore` symlinks

### DIFF
--- a/windows-kvm/debug/.gitignore
+++ b/windows-kvm/debug/.gitignore
@@ -1,1 +1,4 @@
-../buildkite-worker/.gitignore
+images/
+build/
+
+config.toml


### PR DESCRIPTION
I guess we'll acquiesce to `git`'s feelings on this matter.