### PR TITLE
Reduce Windows VM memory allocation to 3GB/core

### DIFF
--- a/windows-kvm/buildkite-worker/common.jl
+++ b/windows-kvm/buildkite-worker/common.jl
@@ -188,7 +188,7 @@ end
 
 function template_kvm_config_command(agent_hostname::String;
                                      num_cpus::Int = 8,
-                                     memory_kb::Int = num_cpus*4*1024*1024)
+                                     memory_kb::Int = num_cpus*3*1024*1024)
     template = joinpath(@__DIR__, "kvm_machine.xml.template")
     target = agent_scratch_xml_path(agent_hostname)
 


### PR DESCRIPTION
Now that https://github.com/JuliaLang/julia/pull/47803 has been merged, we are using [significantly less commit charge](https://github.com/JuliaLang/julia/pull/47803#issuecomment-1338053358), and should be capable of running with only 3GB/core allocated, rather than the currently rather wasteful 4GB/core.