### PR TITLE
Include experimental features on Windows as well

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -45,7 +45,7 @@ disconnect-after-job=true
 disconnect-after-idle-timeout=3600
 git-mirrors-path="/cache/repos"
 experiment="git-mirrors,output-redactor,ansi-timestamps,resolve-commit-after-checkout"
-${BUILDKITE_AGENT_TAGS}
+tags="${BUILDKITE_AGENT_TAGS}"
 EOF
 cp -a buildkite-agent.cfg "${ETC}/"
 

--- a/windows-kvm/buildkite-worker/setup_scripts/0-00-format-data-disk.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-00-format-data-disk.ps1
@@ -1,7 +1,14 @@
-Write-Output " -> Formatting Z:"
-Get-Disk | Where-Object PartitionStyle -eq "RAW" | `
-           Initialize-Disk -PartitionStyle GPT -PassThru | `
-           New-Volume -FileSystem NTFS -DriveLetter Z -FriendlyName 'DATA'
+Write-Output " -> Formatting disk, assigning to C:\cache"
+
+# Format our raw disk as NTFS
+$Disk = (Get-Disk | Where-Object PartitionStyle -eq "RAW")
+$Disk | Initialize-Disk -PartitionStyle GPT -PassThru | New-Volume -FileSystem NTFS -FriendlyName "CACHE"
+
+# Mount it as C:\cache AND Z:\, since we' need to use both for docker (sigh)
+$Partition = Get-Partition -DiskNumber $Disk.Number -PartitionNumber 2
+New-Item -ItemType Directory -Path "C:\cache"
+$Partition | Add-PartitionAccessPath -AccessPath "C:\cache"
+$Partition | Add-PartitionAccessPath -AccessPath "Z:\"
 
 # Ensure that Z: gets mounted automatically
 Set-StorageSetting -NewDiskPolicy OnlineAll

--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -33,9 +33,12 @@ Add-Content -Path "$bk_config" -Value "disconnect-after-idle-timeout=3600"
 # Fetch git tags as well
 Add-Content -Path "$bk_config" -Value "git-fetch-flags=`"-v --prune --tags`""
 
-# Set environment variables to point some important buildkite agent storage to Z:
-New-Item -Path "Z:\" -Name "cache" -ItemType "directory"
-[Environment]::SetEnvironmentVariable("BUILDKITE_PLUGIN_JULIA_CACHE_DIR", "Z:\cache", [System.EnvironmentVariableTarget]::Machine)
+# Enable some experimental features
+Add-Content -Path "$bk_config" -Value "experiment=`"git-mirrors,output-redactor,ansi-timestamps,resolve-commit-after-checkout`""
+
+# Set environment variables to point some important buildkite agent storage to our cache directory
+[Environment]::SetEnvironmentVariable("BUILDKITE_PLUGIN_JULIA_CACHE_DIR", "C:\cache\julia-buildkite-plugin", [System.EnvironmentVariableTarget]::Machine)
+Add-Content -Path "$bk_config" -Value "git-mirrors-path=`"C:\cache\repos`""
 
 # Install all of our hooks
 New-Item -Path "C:\buildkite-agent\hooks" -ItemType "directory"

--- a/windows-kvm/buildkite-worker/setup_scripts/0-06-set-docker-dataroot.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-06-set-docker-dataroot.ps1
@@ -6,7 +6,13 @@ Remove-Item -Recurse -Force "C:\ProgramData\Docker"
 New-Item -Path "C:\ProgramData\Docker" -ItemType Directory
 New-Item -Path "C:\ProgramData\Docker\config" -ItemType Directory
 
-# Set the data-root for docker's daemon
+# NOTE: we can't use `C:\\cache` here because of [0], so we instead
+# bind-mount our cache directory to two separate locations.  The first
+# location, Z:\, is to work around [0], and the second location,
+# C:\cache, is so that when we do transparent mounts for our builds,
+# we can mount C:\cache -> C:\cache inside the container (which doesn't
+# have a Z:\).
+# [0] https://github.com/docker/for-win/issues/8110
 @"
 {
     "data-root": "Z:\\docker-data"
@@ -15,3 +21,6 @@ New-Item -Path "C:\ProgramData\Docker\config" -ItemType Directory
 
 # Allow docker to restart
 Start-Service docker
+
+# Pre-fill our cache drive with the base docker image that all of our images are based on
+docker pull mcr.microsoft.com/windows/servercore:ltsc2022


### PR DESCRIPTION
This one took down our Windows workers for almost a day.  Let me tell
you a story about Windows, Docker, and naive sysadmins (me):

Once upon a time, little old staticfloat thought that he would be able
to easily mirror (pun intended) the `git-mirrors` configuration used on
the Linux, macOS and now FreeBSD workers on the Windows workers as well.
He dutifully copied over the relevant buildkite-agent configuration,
setup a folder within the cache disk `Z:` to hold the cached git clones,
and started up the agent.  The agent booted up just fine, but then he
saw a most peculiar error:

```
docker: Error response from daemon: hcsshim::CreateComputeSystem e56f18be8cf3dd0b0f751bc305f9e8faa358a66e6daca844e17888d3a17ed63b: The parameter is incorrect.
```

A quick google around made it sound like something was wrong with
Hyper-V, so he rebuilt his debugging VM, with the updated configuration,
took a look around, and was surprised to find `docker` working just
fine.  A few more googlings around didn't find anything unusual, so he
started to copy-paste the exact docker commands in, and that was when he
realized that the issue was that the `docker` buildkite plugin was
automatically adding in a bind mount from `Z:\repos\` to `Z:\repos\`
within the container.  But of course, there WAS no `Z:` in the
container.  Massive sigh.

"I know!" thought our brave young sysadmin, "I will mount our cache
drive at `C:\cache` instead of `Z:\`, and all will be well!".  No sooner
does he do this than he finds that the docker daemon refuses to start
up at all, spitting into the Event log: `EvalSymlinks: too many links`.

Lovely.  Just.... lovely.  So our solution is to mount the cache drive
at two locations; `C:\cache` and `Z:\`, and to use one with our build
system, and the other with the docker data-root.