### PR TITLE
Define `nproc` on FreeBSD and use `/usr/bin/env bash` in shebangs

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 shopt -s nullglob

--- a/hooks/environment.d/100_gr_env.sh
+++ b/hooks/environment.d/100_gr_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Export environment variables to ensure that GR runs well headless
 export GKSwstype=100

--- a/hooks/environment.d/101_julia_num_cores.sh
+++ b/hooks/environment.d/101_julia_num_cores.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This defines `JULIA_CPU_THREADS` to be `nproc`.
 # If you want a different value, I suggest overriding this value within
@@ -16,6 +16,11 @@ if [[ "$(uname)" == "Darwin" ]]; then
             sysctl -n "hw.ncpu"
         }
     fi
+    export -f nproc
+elif [[ "$(uname)" == "FreeBSD" ]]; then
+    function nproc() {
+        sysctl -n "hw.ncpu"
+    }
     export -f nproc
 fi
 

--- a/hooks/environment.d/999_cryptic_unlock.sh
+++ b/hooks/environment.d/999_cryptic_unlock.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 


### PR DESCRIPTION
The `nproc` bit should hopefully fix the failure in my julia-buildkite PR.