### PR TITLE
FreeBSD: Reboot after the buildkite job finishes

### DIFF
--- a/freebsd-kvm/base-image/setup_scripts/user.sh
+++ b/freebsd-kvm/base-image/setup_scripts/user.sh
@@ -6,5 +6,6 @@ echo "${PASSWORD}" | pw usermod root -h 0
 
 pw useradd -n ${USER} -s $(which bash) -m -w yes
 pw groupmod wheel -m ${USER}
+pw groupmod operator -m ${USER}
 echo "${PASSWORD}" | pw usermod ${USER} -h 0
 echo "${USER} ALL = NOPASSWD: ALL" >> /usr/local/etc/sudoers

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -81,19 +81,19 @@ pidfile=/var/run/buildkite.pid
 
 load_rc_config \${name}
 
+start_cmd="\${name}_start"
+stop_cmd=":"
 buildkite_user=\${buildkite_account}
 required_files="\${buildkite_config}"
 
-buildkite_cmd() {
+buildkite_start() {
     /usr/bin/env \
         \${buildkite_env} \
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
-        buildkite-agent start --config \${buildkite_config}
+        /usr/local/bin/buildkite-agent start --config \${buildkite_config}
     shutdown -r now
 }
-
-command="buildkite_cmd"
 
 run_rc_command "\$1"
 EOF

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -66,9 +66,38 @@ EOF
 chown root:wheel /usr/local/etc/rc.conf.d/buildkite
 chmod 600 /usr/local/etc/rc.conf.d/buildkite
 
-curl "https://cgit.freebsd.org/ports/plain/devel/buildkite-agent/files/buildkite.in" | \
-    sed -e 's|%%PREFIX%%|/usr/local|' -e "s|%%ETCDIR%%|${ETC}|" > \
-    /etc/rc.d/buildkite
+cat > /etc/rc.d/buildkite <<EOF
+#!/bin/sh
+
+# PROVIDE: buildkite
+# REQUIRE: LOGIN NETWORKING SERVERS
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name=buildkite
+rcvar=buildkite_enable
+pidfile=/var/run/buildkite.pid
+
+load_rc_config \${name}
+
+buildkite_user=\${buildkite_account}
+required_files="\${buildkite_config}"
+
+buildkite_cmd() {
+    /usr/bin/env \
+        \${buildkite_env} \
+        HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
+        BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
+        buildkite-agent start --config \${buildkite_config}
+    shutdown -r now
+}
+
+command="buildkite_cmd"
+
+run_rc_command "\$1"
+EOF
+
 chown root:wheel /etc/rc.d/buildkite
 chmod 555 /etc/rc.d/buildkite
 

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -92,7 +92,7 @@ buildkite_start() {
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
         /usr/local/bin/buildkite-agent start --config \${buildkite_config}
-    shutdown -r now
+    shutdown -p now
 }
 
 run_rc_command "\$1"


### PR DESCRIPTION
The approach:
- Allow the user to reboot without root permissions by adding them to the `operator` group
- Rather than reusing the [provided rc.d script](https://cgit.freebsd.org/ports/tree/devel/buildkite-agent/files/buildkite.in) from the [buildkite-agent port](https://www.freshports.org/devel/buildkite-agent/), we can cowboy our own by skimming the FreeBSD [article](https://docs.freebsd.org/en/articles/rc-scripting/) on rc.d scripting and making something that looks plausibly correct
- Set the command that gets run at service start to invoke `buildkite-agent start` then `shutdown -r now`
- Set the `buildkite_user` variable so that the service's command is run as the specified user

Will this work as intended? Who knows!