### PR TITLE
Add `--dissociate` to windows git clone flags

### DIFF
--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -32,6 +32,7 @@ Add-Content -Path "$bk_config" -Value "disconnect-after-idle-timeout=3600"
 
 # Fetch git tags as well
 Add-Content -Path "$bk_config" -Value "git-fetch-flags=`"-v --prune --tags`""
+Add-Content -Path "$bk_config" -Value "git-clone-flags=`"-v --dissociate`""
 
 # Enable some experimental features
 Add-Content -Path "$bk_config" -Value "experiment=`"git-mirrors,output-redactor,ansi-timestamps,resolve-commit-after-checkout`""


### PR DESCRIPTION
This causes the "git mirrors" experiment, which uses a local cache of the repositories used in the build process to now create a standalone clone in the build directory.  This is more disk traffic, but it breaks the link between the build directory and the cache directory where the git repository is stored.  This is necessary because I recently added a better way of mounting the cache disk, but `git` seems to normalize the path to the cache disk in an odd way, finding it moutned at `Z:` (which is true) instead of the file path given to it, at `C:\cache` (which is also true).  This causes problems inside of docker, where there is only `C:\cache`.

An alternative to this is to manually overwrite
`.git/objects/info/alternates` with `C:\cache\...`, but that feels a little bit dirtier.