### PR TITLE
Store build cache in a per-BRG configurable cache directory

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -30,6 +30,9 @@ struct BuildkiteRunnerGroup
     # A per-brg override for what `tempdir()` should return
     tempdir_path::Union{String,Nothing}
 
+    # Where this brg should store its cache files
+    cache_path::Union{String,Nothing}
+
     # Whether this runner should be run in verbose mode
     verbose::Bool
 end
@@ -43,6 +46,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
     platform = parse(Platform, get(config, "platform", triplet(HostPlatform())))
     source_image = get(config, "source_image", "")
     tempdir_path = get(config, "tempdir", nothing)
+    cache_path = get(config, "cachedir", @get_scratch!("agent-cache"))
     verbose = get(config, "verbose", false)
 
     # Encode some information about this runner
@@ -73,6 +77,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
         platform,
         source_image,
         tempdir_path,
+        cache_path,
         verbose,
     )
 end
@@ -96,3 +101,5 @@ end
 function Base.tempdir(brg::BuildkiteRunnerGroup)
     return something(brg.tempdir_path, tempdir())
 end
+
+cachedir(brg::BuildkiteRunnerGroup) = brg.cache_path

--- a/hooks/environment.d/500_windows_debugging.sh
+++ b/hooks/environment.d/500_windows_debugging.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-LOG_FILES=(
-    # This log file should get cleared out every boot
-    "${HOME}/startup.log"
-    # This log file should persist as long as the cache drive does
-    "$(cygpath "${BUILDKITE_PLUGIN_JULIA_CACHE_DIR}")/startup.log"
-)
-
 function log() {
     # Read the message in from stdin
     MSG="$(</dev/stdin)"
@@ -43,5 +36,12 @@ function debug_startup() {
 
 
 if [[ "$(uname 2>/dev/null)" == MINGW* ]]; then
+    LOG_FILES=(
+        # This log file should get cleared out every boot
+        "${HOME}/startup.log"
+        # This log file should persist as long as the cache drive does
+        "$(cygpath "${BUILDKITE_PLUGIN_JULIA_CACHE_DIR}")/startup.log"
+    )
+
     debug_startup
 fi

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -232,7 +232,7 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
                        rootfs_dir::String = @artifact_str("buildkite-agent-rootfs", brg.platform),
                        agent_token_path::String = joinpath(dirname(@__DIR__), "secrets", "buildkite-agent-token"),
                        agent_name::String = brg.name,
-                       cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
+                       cache_path::String = joinpath(cachedir(brg), agent_name),
                        temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name),
                        )
     repo_root = dirname(@__DIR__)
@@ -455,7 +455,7 @@ const systemd_unit_name_stem = "buildkite-sandbox-"
 
 function debug_shell(brg::BuildkiteRunnerGroup;
                      agent_name::String = brg.name,
-                     cache_path::String = joinpath(@get_scratch!("agent-cache"), agent_name),
+                     cache_path::String = joinpath(cachedir(brg), agent_name),
                      temp_path::String = joinpath(tempdir(brg), "agent-tempdirs", agent_name))
     config = SandboxConfig(brg; agent_name, cache_path, temp_path)
 


### PR DESCRIPTION
This allows overriding the cache files via the `cachedir` directive in the `config.toml`.  You can even assign two different BRGs with two different cache directories, to split workers across two disks, for instance.