### PR TITLE
[freebsd-kvm] Wrap the rc.d buildkite-agent invocation in `su`

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -87,11 +87,11 @@ buildkite_user=\${buildkite_account}
 required_files="\${buildkite_config}"
 
 buildkite_start() {
-    /usr/bin/env \
+    su ${USERNAME} -c "/usr/bin/env \
         \${buildkite_env} \
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
-        /usr/local/bin/buildkite-agent start --config \${buildkite_config}
+        /usr/local/bin/buildkite-agent start --config \${buildkite_config}"
     shutdown -p now
 }
 


### PR DESCRIPTION
According to a [discussion on the FreeBSD forum](https://forums.freebsd.org/threads/how-to-run-rc-d-service-as-specific-user.86879/), the specified user may not actually be the one who owns the `buildkite-agent` process. While buildkite seems to be configured to run jobs as said user, there seems to be some kind of configuration mismatch since the Julia tests claim they're being run as root (see test log in https://github.com/JuliaCI/julia-buildkite/pull/266). We can try to fix this by wrapping the command to launch `buildkite-agent` in `su`.