### PR TITLE
Rename `install-zstd.sh` and also install GnuPG

### DIFF
--- a/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl.template
+++ b/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl.template
@@ -70,7 +70,7 @@ build {
             "setup_scripts/install-buildkite-agent.sh",
             "setup_scripts/install-wireguard.sh",
             "setup_scripts/install-telegraf.sh",
-            "setup_scripts/install-zstd.sh",
+            "setup_scripts/install-more-dependencies.sh",
             "setup_scripts/install-cryptic-secrets.sh",
         ]
     }

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-more-dependencies.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-more-dependencies.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pkg install -y zstd gnupg

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-zstd.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-zstd.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-pkg install -y zstd


### PR DESCRIPTION
This ensures that `gpg` and `gpgconf` are available in the buildkite worker image for tarball signing (see job failure in https://github.com/JuliaCI/julia-buildkite/pull/266)