### PR TITLE
[freebsd-kvm] Ignore nonzero exits from `buildkite-agent`

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -53,8 +53,6 @@ EOF
 cp -a buildkite-agent.cfg "${ETC}/"
 chown -R ${USERNAME}:${USERNAME} "${ETC}"
 
-echo "#!/bin/sh\nshutdown -p now" > "${ETC}/hooks/agent-shutdown.sh"
-
 mkdir -p /usr/local/etc/rc.conf.d
 cat > /usr/local/etc/rc.conf.d/buildkite <<EOF
 buildkite_enable=YES
@@ -87,13 +85,17 @@ buildkite_user=\${buildkite_account}
 required_files="\${buildkite_config}"
 
 buildkite_start() {
-    trap "date >>/var/log/shutdown.log; shutdown -p now >>/var/log/shutdown.log 2>>/var/log/shutdown.log" EXIT
+    exec >> /var/log/buildkite.log
+    exec 2>&1
+    set -x
     su ${USERNAME} -c "/usr/bin/env \
         \${buildkite_env} \
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
         /usr/local/bin/buildkite-agent start --config \${buildkite_config}"
+    halt -l -p
 }
+
 
 run_rc_command "\$1"
 EOF

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -91,7 +91,8 @@ buildkite_start() {
         \${buildkite_env} \
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
-        /usr/local/bin/buildkite-agent start --config \${buildkite_config}"
+        /usr/local/bin/buildkite-agent start --config \${buildkite_config} \
+        || true"
     shutdown -p now
 }
 

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -71,7 +71,7 @@ cat > /etc/rc.d/buildkite <<EOF
 
 # PROVIDE: buildkite
 # REQUIRE: LOGIN NETWORKING SERVERS
-# KEYWORD: shutdown
+# KEYWORD:
 
 . /etc/rc.subr
 
@@ -87,13 +87,12 @@ buildkite_user=\${buildkite_account}
 required_files="\${buildkite_config}"
 
 buildkite_start() {
+    trap "date >>/var/log/shutdown.log; shutdown -p now >>/var/log/shutdown.log 2>>/var/log/shutdown.log" EXIT
     su ${USERNAME} -c "/usr/bin/env \
         \${buildkite_env} \
         HOME=\$(pw usershow \${buildkite_account} | cut -d: -f9) \
         BUILDKITE_AGENT_TOKEN=\${buildkite_token} \
-        /usr/local/bin/buildkite-agent start --config \${buildkite_config} \
-        || true"
-    shutdown -p now
+        /usr/local/bin/buildkite-agent start --config \${buildkite_config}"
 }
 
 run_rc_command "\$1"


### PR DESCRIPTION
It seems that when the `buildkite-agent` process exits with a nonzero code, the `buildkite_start` function in the rc.d script returns before it gets to `shutdown`. This leaves VMs with failed jobs just sitting around, since `buildkite-agent` is no longer running and nothing else is there to shut them down.

That's our working hypothesis, anyway. I attempted to test it by making this change locally on a worker and manually restarting the `buildkite` service. The job it picked up finished successfully so this didn't really get tested, but at least it didn't break anything.