### PR TITLE
Load FreeBSD virtio drivers at boot time

### DIFF
--- a/freebsd-kvm/base-image/http/installerconfig
+++ b/freebsd-kvm/base-image/http/installerconfig
@@ -8,6 +8,9 @@ sysrc ifconfig_DEFAULT=SYNCDHCP
 sysrc sshd_enable=YES
 sysrc sendmail_enable=NONE
 sysrc -f /boot/loader.conf autoboot_delay=-1
+sysrc -f /boot/loader.conf virtio_load="YES"
+sysrc -f /boot/loader.conf virtio_pci_load="YES"
+sysrc -f /boot/loader.conf if_vtnet_load="YES"
 
 sed -i '' -e 's/^#UseDNS yes/UseDNS no/' /etc/ssh/sshd_config
 sed -i '' -e 's/^#PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config


### PR DESCRIPTION
We've specified virtio as the network adapter for KVM and it works but we get occasional timeouts from httpbingo and GitHub while running the Julia test suite, which suggests a possible network setup issue. FreeBSD has virtio kernel modules that can be loaded on boot so we can try loading those to see if they help. See `man 4 virtio` for where these flags came from.