### PR TITLE
Fix windows long paths (again)

### DIFF
--- a/windows-kvm/base-image/setup_scripts/2-03-install-git.ps1
+++ b/windows-kvm/base-image/setup_scripts/2-03-install-git.ps1
@@ -24,13 +24,13 @@ Start-Process -Wait $env:TEMP\git-stable.exe -ArgumentList /silent
     [EnvironmentVariableTarget]::Machine)
 
 # Tell git to use native windows SSH
-& "C:\Program Files\Git\bin\git.exe" config --system core.sshCommand "'C:\Windows\System32\OpenSSH\ssh.exe'"
+& "C:\Program Files\Git\bin\git.exe" config --global core.sshCommand "'C:\Windows\System32\OpenSSH\ssh.exe'"
 
 # Tell git to create real symlinks
-& "C:\Program Files\Git\bin\git.exe" config --system core.symlinks "true"
+& "C:\Program Files\Git\bin\git.exe" config --global core.symlinks "true"
 
 # Tell git to use longpaths (since we enabled it previously)
-& "C:\Program Files\Git\bin\git.exe" config --system core.longpaths "true"
+& "C:\Program Files\Git\bin\git.exe" config --global core.longpaths "true"
 
 # Enable ssh-agent service, so that it can be started by buildkite plugins
 Set-Service -Name ssh-agent -StartupType Manual

--- a/windows-kvm/debug/setup_scripts/0-10-install-julia.ps1
+++ b/windows-kvm/debug/setup_scripts/0-10-install-julia.ps1
@@ -1,4 +1,4 @@
-$version = "1.8.2"
+$version = "1.8.5"
 $majmin = $version.Substring(0, $version.lastIndexOf('.'))
 Write-Output "Installing Julia v$version..."
 $juliaUrl = "https://julialang-s3.julialang.org/bin/winnt/x64/${majmin}/julia-${version}-win64.zip"


### PR DESCRIPTION
Turns out that `--system` is less than ideal if a pipeline can bring its own `git.exe`.