### PR TITLE
Lock to buildkite agent v3.39.0 on FreeBSD, and disable git-mirrors

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -14,11 +14,8 @@ echo "-> Installing buildkite-agent"
 # We want to install buildkite in the same way as the port so that we can use it as
 # a system service but we want to use buildkite's official binaries and distribution
 # info to ensure consistency with other systems.
-
-INFO="$(curl -s "https://buildkite.com/agent/releases/latest?platform=freebsd&arch=amd64&system=freebsd&machine=amd64")"
-VERSION="$(echo "${INFO}" | grep '^version=' | cut -d'=' -f2)"
-FILENAME="$(echo "${INFO}" | grep '^filename=' | cut -d'=' -f2)"
-URL="$(echo "${INFO}" | grep '^url=' | cut -d'=' -f2)"
+URL="https://github.com/buildkite/agent/releases/download/v3.39.0/buildkite-agent-freebsd-amd64-3.39.0.tar.gz"
+FILENAME="$(basename "${URL}")"
 
 mkdir -p /tmp/buildkite-install
 cd /tmp/buildkite-install
@@ -46,8 +43,10 @@ shell="$(which bash) -c"
 git-fetch-flags="-v --prune --tags"
 disconnect-after-job=true
 disconnect-after-idle-timeout=3600
-git-mirrors-path="/cache/repos"
-experiment="git-mirrors,output-redactor,ansi-timestamps,resolve-commit-after-checkout"
+
+# Disable this mirrors path, as github does not seem to respond to us.  :(
+#git-mirrors-path="/cache/repos"
+experiment="output-redactor,ansi-timestamps,resolve-commit-after-checkout"
 tags="${BUILDKITE_AGENT_TAGS}"
 EOF
 cp -a buildkite-agent.cfg "${ETC}/"


### PR DESCRIPTION
Unfortunately, our FreeBSD agents seem to have a hard time cloning with `--mirror`, something about the request borks github and we end up timing out, or getting a bad response, or something.  By disabling the `--mirror` optimization, we are able to get things working.  I suppose we'll try turning it on again in the future.  This used to work in FreeBSD 12, so I suspect something like libcurl v8.1 is causing an issue here.