### PR TITLE
Disable windows debugging for now

### DIFF
--- a/hooks/environment.d/500_windows_debugging.sh
+++ b/hooks/environment.d/500_windows_debugging.sh
@@ -35,7 +35,8 @@ function debug_startup() {
 }
 
 
-if [[ "$(uname 2>/dev/null)" == MINGW* ]]; then
+# DISABLED: We don't need this right now, let's clean up our build logs a bit
+if false #[[ "$(uname 2>/dev/null)" == MINGW* ]]; then
     LOG_FILES=(
         # This log file should get cleared out every boot
         "${HOME}/startup.log"


### PR DESCRIPTION
Hopefully, Gabriel's PR [0] will have fixed the issues we were seeing, and in any case, nobody was looking at this debugging information recently, so let's just drop it and clean up our build logs.

[0] https://github.com/JuliaCI/julia-buildkite/pull/361