### PR TITLE
Set Linux cancellation grace period to 5 minutes

### DIFF
--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -387,6 +387,7 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::
                                 --experiment=resolve-commit-after-checkout
                                 --git-mirrors-path=/cache/repos
                                 --git-fetch-flags=\"-v --prune --tags\"
+                                --cancel-grace-period=300
                                 --tags=$(join(tags_with_queues, ","))
                                 --name=$(agent_name)
             ```


### PR DESCRIPTION
This should give our workers a chance to perform final cleanup such as uploading core files and such.  A little annoying that I have to enable this globally rather than on a pipeline-by-pipeline basis, but c'est la vie.