### PR TITLE
Reconfigure DNS resolution on FreeBSD VMs

### DIFF
--- a/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl.template
+++ b/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl.template
@@ -72,6 +72,7 @@ build {
             "setup_scripts/install-telegraf.sh",
             "setup_scripts/install-more-dependencies.sh",
             "setup_scripts/install-cryptic-secrets.sh",
+            "setup_scripts/configure-dns-resolver.sh",
         ]
     }
 }

--- a/freebsd-kvm/buildkite-worker/setup_scripts/configure-dns-resolver.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/configure-dns-resolver.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+# The nameserver set by DHCP is the host machine's IP. For whatever reason, it takes
+# a full 30 seconds to report NXDOMAIN for invalid domains, which interacts poorly
+# with Julia's Downloads tests, which set a timeout. There are a few complementary ways
+# we could paper over this, among them:
+#   - Use Google's DNS server, 8.8.8.8, either before or after the host. The former is
+#     significantly faster.
+#   - Reduce the amount of time the resolver waits for a response, e.g. `timeout:1` to
+#     wait only 1 second. The default is 5 seconds, with exponential backoff.
+#   - Reduce the number of times the resolver sends a query to each nameserver, e.g.
+#     `attempts:1` to give up after a single query to each nameserer. Default is 2.
+# We'll only do the first of these as the resolver option changes could potentially
+# make things less robust to brief network hiccups.
+cat > /etc/resolvconf.conf <<EOF
+prepend_nameservers=8.8.8.8
+EOF
+resolvconf -u


### PR DESCRIPTION
We've been experiencing a failure in Julia's Downloads tests on FreeBSD, reproducible only in our VMs: the request to `https://domain.invalid` hits the 30-second timeout set by default in Downloads because it takes a full 30 seconds for the resolver to report `NXDOMAIN`. I have no idea why, and I can't even reproduce it in a FreeBSD VM on my local machine. Absent a real fix, we can apply a band-aid in the meantime: prefer Google's nameserver in the DNS resolver configuration. In the debugging VM on amdci6, this allows the Downloads tests to pass succesfully.