### PR TITLE
macOS: Avoid buildkite-agent crash by using shorted sockets path

### DIFF
--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -196,6 +196,7 @@ function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
         # Invoke agent inside of sandbox
         sandbox-exec -f $(sb_path) $(agent_path) start \\
             --disconnect-after-job \\
+            --sockets-path=$(temp_path) \\
             --hooks-path=$(hooks_path) \\
             --build-path=$(cache_path)/build \\
             --experiment=git-mirrors,output-redactor,ansi-timestamps,resolve-commit-after-checkout \\


### PR DESCRIPTION
Otherwise we get:

> 🚨 Error: Error setting up Job API: creating job API server: creating socket server: socket path /private/var/tmp/agent-tempdirs/default-grannysmith-C07ZQ07RJYVY.0/home/.buildkite-agent/sockets/job-api/37483-34030.sock is too long (path length: 121, max 104 characters). This is a limitation of your host OS