### PR TITLE
macOS: Run agent in a loop instead of relying on KeepAlive

### DIFF
--- a/common/coredump_config.jl
+++ b/common/coredump_config.jl
@@ -41,8 +41,7 @@ function set_coredump_pattern(pattern::AbstractString)
         label = "org.julialang.buildkite.corefile"
         config = LaunchctlConfig(
             label,
-            [Sys.which("sysctl"), "-w", "kern.corefile=$(pattern)"];
-            keepalive=false,
+            [Sys.which("sysctl"), "-w", "kern.corefile=$(pattern)"]
         )
         mktempdir() do dir
             open(joinpath(dir, "config"); write=true) do io

--- a/common/mac_launchctl_config.jl
+++ b/common/mac_launchctl_config.jl
@@ -19,7 +19,7 @@ struct LaunchctlConfig
     # Whether the job should be restarted after it dies
     keepalive::Union{NamedTuple,Bool,Nothing}
 
-    function LaunchctlConfig(label, target; env = Dict{String,String}(), cwd = nothing, logpath = nothing, keepalive = true)
+    function LaunchctlConfig(label, target; env = Dict{String,String}(), cwd = nothing, logpath = nothing, keepalive = nothing)
         return new(label, target, env, cwd, logpath, keepalive)
     end
 end

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -227,10 +227,7 @@ function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
             if ((ts_now - ts_boot > 24*60*60)); then
                 echo "Rebooting machine after 24 hours of uptime"
                 sudo -n /sbin/shutdown -r now
-
-                # Give the system the time to shut down,
-                # preventing a new job from getting picked up
-                sleep 30
+                break
             fi
         """)
 
@@ -242,6 +239,9 @@ function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
                 break
             fi
         done
+
+        # Return success, which will result in the service _not_ restarting
+        exit 0
         """)
     end
 


### PR DESCRIPTION
Hopefully fixes https://github.com/JuliaCI/sandboxed-buildkite-agent/issues/86.

Reading the docs I figured that an exit code of 255 would be what happens when killing the agent from the WebUI, but that seems to run into https://github.com/buildkite/agent/issues/3052. Ideally we wouldn't have to use `--disconnect-after-job`, but I don't see another way to safely manage the worker state.