### PR TITLE
Change default systemd restart policy

### DIFF
--- a/common/linux_systemd_config.jl
+++ b/common/linux_systemd_config.jl
@@ -8,11 +8,11 @@ struct SystemdRestartConfig
     StartLimitBurst::Int
     StartLimitIntervalSec::Int
 
-    # Give some reasonable defaults, such as trying to restart every second,
-    # but giving up if we try to restart 10 times within 2 minutes.
-    function SystemdRestartConfig(RestartSec::Int = 1,
-                                  StartLimitBurst::Int = 10,
-                                  StartLimitIntervalSec::Int = StartLimitBurst * (RestartSec + 10) + 10)
+    # Give some reasonable defaults, such as trying to restart every minute,
+    # but giving up if we try to restart 30 times within one hour.
+    function SystemdRestartConfig(RestartSec::Int = 60,
+                                  StartLimitBurst::Int = 30,
+                                  StartLimitIntervalSec::Int = StartLimitBurst * RestartSec * 2)
         return new(RestartSec, StartLimitBurst, StartLimitIntervalSec)
     end
 end


### PR DESCRIPTION
On `amdci6` we observed that the systemd services fail somewhat frequently because permission problems on `*.qcow2` files. While these issues seem to resolve by themselves after a few minutes, quickly trying to restart the services only causes them to hit the maximum number of retries in the given interval (max 10 retries in 2 minutes by default), forcing someone to log into the machine to manually restart the systemd service.

With this change the service are tried to restart every minute rather than every second, allowing for more attempts over a larger time period. This could cause some agents to take longer to come back after a failure (1 minute vs 1 second), but also reduce the need for someone to manually restart them, which would cause much longer downtimes.