### PR TITLE
Override `BUILDKITE_PLUGIN_JULIA_ARCH` with the given `arch`.

### DIFF
--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -267,6 +267,7 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
     env_maps = Dict(
         "BUILDKITE_PLUGIN_JULIA_CACHE_DIR" => "/cache/julia-buildkite-plugin",
         "BUILDKITE_AGENT_TOKEN" => String(chomp(String(read(agent_token_path)))),
+        "BUILDKITE_PLUGIN_JULIA_ARCH" => brg.tags["arch"],
         "HOME" => "/root",
 
         # For anyone who wants to do nested sandboxing, tell them to store


### PR DESCRIPTION
This should never be wrong (even if it is unnecessary to override in most cases) and will help reduce issues with the `armv7l` buildbots which are actually `aarch64` processors, but are running `armv7l` rootfs images, and thus cannot run `aarch64` programs.