### PR TITLE
Update FreeBSD image from 13.2 to 13.4

### DIFF
--- a/freebsd-kvm/README.md
+++ b/freebsd-kvm/README.md
@@ -22,7 +22,7 @@ There are three chunks of configuration here:
 
 ## System Version
 
-The images here currently use *FreeBSD 13.2-RELEASE*.
+The images here currently use *FreeBSD 13.4-RELEASE*.
 
 Generally speaking, binaries built on FreeBSD version `x` are incompatible with FreeBSD version `x - 1`.
 However, the opposite is not true: binaries built on older versions are forward-compatible.

--- a/freebsd-kvm/base-image/freebsd13.pkr.hcl
+++ b/freebsd-kvm/base-image/freebsd13.pkr.hcl
@@ -9,8 +9,8 @@ variable "password" {
 }
 
 source "qemu" "freebsd13" {
-    iso_url = "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/13.2/FreeBSD-13.2-RELEASE-amd64-disc1.iso.xz"
-    iso_checksum = "52a1420db86802cfab8bafa36eccaa78c8b65b59673cbdf690e4b57f9d80f01f"
+    iso_url = "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/13.4/FreeBSD-13.4-RELEASE-amd64-disc1.iso.xz"
+    iso_checksum = "e00ce3cc1b8b388dfea4f8557d490eef6d287e0bd0a64d7d5862b4b324d5f909"
 
     # Note, you may need to tune this if you're on a slow computer ;)
     boot_wait = "5s"


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/57874#issuecomment-2748690414. As of https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/418, Yggdrasil is building for FreeBSD 13.4 on x86-64 rather than 13.2, so we need to update the CI image here so that BinaryBuilder dependencies can be safely upgraded without weird breakages.

@staticfloat, can you help with deploying this once it's merged?