### PR TITLE
Windows: Add `distclean` target

### DIFF
--- a/windows-kvm/buildkite-worker/Makefile
+++ b/windows-kvm/buildkite-worker/Makefile
@@ -9,3 +9,6 @@ down uninstall:
 clean:
 	rm -rf build
 	rm -rf images
+
+distclean: clean down
+	rm -rf ~/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent_build/win2k22*


### PR DESCRIPTION
This will clean out the installed VM images as well.  This is basically how I fixed the `C:/cache` failures