### PR TITLE
Update 999_cryptic_unlock.sh

### DIFF
--- a/hooks/environment.d/999_cryptic_unlock.sh
+++ b/hooks/environment.d/999_cryptic_unlock.sh
@@ -9,7 +9,7 @@ set -eou pipefail
 ## agent should exit, causing the docker container to restart and restore the deleted files.
 ## This gives us the capability to deny access to these files to later steps within the
 ## current buildkite job.
-SECRETS_MOUNT_POINT="${BUILDKITE_PLUIGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/secrets}"
+SECRETS_MOUNT_POINT="${BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/secrets}"
 
 ## The secrets that must be contained within:
 ##    - `agent.{key,pub}`: An RSA private/public keypair (typically generated via the


### PR DESCRIPTION
Sync with https://github.com/JuliaCI/cryptic-buildkite-plugin/pull/38, one typo at a time.