### PR TITLE
Fix more typos in SECRETS_MOUNT_POINT plugin variables.

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -58,7 +58,7 @@ buildkite_enable=YES
 buildkite_token=${TOKEN}
 buildkite_account=${USERNAME}
 buildkite_config=${ETC}/buildkite-agent.cfg
-buildkite_env="BUILDKITE_PLUGIN_JULIA_CACHE_DIR=/cache/julia-buildkite-plugin BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT=/usr/home/${USERNAME}/secrets"
+buildkite_env="BUILDKITE_PLUGIN_JULIA_CACHE_DIR=/cache/julia-buildkite-plugin BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT=/usr/home/${USERNAME}/secrets"
 EOF
 chown root:wheel /usr/local/etc/rc.conf.d/buildkite
 chmod 600 /usr/local/etc/rc.conf.d/buildkite

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -322,7 +322,7 @@ function build_seatbelt_env(temp_path::String, cache_path::String;
         "HOME" => joinpath(temp_path, "home"),
         "BUILDKITE_BIN_PATH" => artifact"buildkite-agent",
         "BUILDKITE_PLUGIN_JULIA_CACHE_DIR" => cache_path,
-        "BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT" => joinpath(cache_path, "secrets"),
+        "BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT" => joinpath(cache_path, "secrets"),
         "BUILDKITE_AGENT_TOKEN" => String(chomp(String(read(agent_token_path)))),
         "PATH" => join(paths, ":"),
         "TERM" => "screen",

--- a/windows-kvm/buildkite-worker/setup_scripts/0-04-install-cryptic-secrets.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-04-install-cryptic-secrets.ps1
@@ -7,4 +7,4 @@ Copy-Item -Path "$PSScriptRoot\..\secrets\agent.pub" -Destination "C:\secrets"
 Copy-Item -Path "$PSScriptRoot\..\secrets\buildkite-api-token" -Destination "C:\secrets"
 
 # Tell the cryptic environment hook how to find our secrets
-[Environment]::SetEnvironmentVariable("BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT", "C:\secrets", [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT", "C:\secrets", [System.EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
Counterpart of https://github.com/JuliaCI/cryptic-buildkite-plugin/pull/38, extending https://github.com/JuliaCI/sandboxed-buildkite-agent/pull/105 and https://github.com/JuliaCI/sandboxed-buildkite-agent/pull/106

The fact that we're apparently not using a fixed version of cryptic across CI pipelines (I guess it should be tagged as `v3`, but , means that the above change may result in things breaking until the workers are updated to reflect the corrected naming.

cc @IanButterworth @fredrikekre 