### PR TITLE
Windows: Delay Buildkite start until other services have started + 30s.

### DIFF
--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -17,6 +17,11 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 & nssm set buildkite-agent ObjectName "$env:UserDomain\$env:UserName" "$env:windows_password"
 & nssm set buildkite-agent AppExit "Default" "Exit"
 & nssm set buildkite-agent AppRestartDelay "10000"
+& nssm set buildkite-agent Start "SERVICE_DELAYED_AUTO_START"
+
+# Reduce the delay start
+$regPath = "HKLM:\SYSTEM\CurrentControlSet\Control"
+Set-ItemProperty -Path $regPath -Name "AutoStartDelay" -Value 30000 -Type DWord
 
 # Tell `nssm` to restart the computer after the service exits
 $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\buildkite-agent\Parameters\AppEvents\Exit"


### PR DESCRIPTION
This should make sure any early reboot during bringup, e.g., after Windows has reconfigured itself because it thinks the hardware has changed, cannot race with Buildkite starting and breaking itself because it can only pick up a job once. Conveniently, this also works around the issue that during image build, Buildkite is started once, resulting in it being possible that the built images don't have secrets anymore if it happens to pick up a job in that moment.