### PR TITLE
linux-sandbox: support cpuset setup on cgroup v1 and v2

### DIFF
--- a/linux-sandbox.jl/cgroup_wrapper.sh
+++ b/linux-sandbox.jl/cgroup_wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# The sandbox runner will always mount our own cgroup at this special mountpoint
-echo "$$" > /usr/lib/cpuset/self/tasks
-
-# Sub off to the given process
-exec "$@"

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -204,6 +204,102 @@ function condense_cpu_selection(cpus::Vector{Int})
     return join(ret, ",")
 end
 
+function cgroup_agent_host_path(agent_name::String)
+    if isdir("/sys/fs/cgroup/cpuset")
+        return "/sys/fs/cgroup/cpuset/$(agent_name)"
+    elseif isfile("/sys/fs/cgroup/cgroup.controllers")
+        has_subtree_control(path) = isfile("$(path)/cgroup.subtree_control")
+
+        uid = Sandbox.getuid()
+        user_service_path = "/sys/fs/cgroup/user.slice/user-$(uid).slice/user@$(uid).service"
+        if isdir(user_service_path) && has_subtree_control(user_service_path)
+            return "$(user_service_path)/$(agent_name)"
+        end
+
+        for line in eachline("/proc/self/cgroup")
+            if startswith(line, "0::")
+                cgroup_rel = line[4:end]
+                cgroup_rel = chomp(cgroup_rel)
+                if cgroup_rel == "/"
+                    return "/sys/fs/cgroup/$(agent_name)"
+                end
+                # cgroup_rel is absolute (starts with '/'), so join manually.
+                candidate_root = "/sys/fs/cgroup$(cgroup_rel)"
+                if has_subtree_control(candidate_root)
+                    return "$(candidate_root)/$(agent_name)"
+                end
+                break
+            end
+        end
+
+        if has_subtree_control("/sys/fs/cgroup")
+            return "/sys/fs/cgroup/$(agent_name)"
+        end
+
+        error("Unable to resolve cgroup v2 root with cgroup.subtree_control")
+    else
+        error("Unable to detect a supported cgroup layout (expected cpuset v1 or unified v2)")
+    end
+end
+
+function cgroup_agent_join_path(agent_name::String)
+    agent_path = cgroup_agent_host_path(agent_name)
+    if isdir("/sys/fs/cgroup/cpuset")
+        return joinpath(agent_path, "tasks")
+    elseif isfile("/sys/fs/cgroup/cgroup.controllers")
+        return joinpath(agent_path, "cgroup.procs")
+    else
+        error("Unable to detect a supported cgroup layout (expected cpuset v1 or unified v2)")
+    end
+end
+
+function wrap_command_in_cgroup(agent_name::String, cmd::Cmd)
+    wrapper_path = joinpath(@__DIR__, "host_cgroup_wrapper.sh")
+    wrapped_cmd = Cmd(
+        Cmd(vcat([wrapper_path, cgroup_agent_join_path(agent_name)], cmd.exec));
+        dir=cmd.dir,
+        ignorestatus=cmd.ignorestatus,
+    )
+    if cmd.env === nothing
+        return wrapped_cmd
+    end
+    return setenv(wrapped_cmd, cmd.env)
+end
+
+function running_under_user_service_scope()
+    user_service_path = "/user.slice/user-$(Sandbox.getuid()).slice/user@$(Sandbox.getuid()).service"
+    for line in eachline("/proc/self/cgroup")
+        if startswith(line, "0::")
+            return startswith(chomp(line[4:end]), user_service_path)
+        end
+    end
+    return false
+end
+
+function wrap_command_in_user_service_scope(cmd::Cmd)
+    scoped_cmd = Cmd(
+        Cmd(vcat([
+            "systemd-run",
+            "--user",
+            "--scope",
+            "--quiet",
+            "--same-dir",
+            "--collect",
+        ], cmd.exec));
+        dir=cmd.dir,
+        ignorestatus=cmd.ignorestatus,
+    )
+    if cmd.env === nothing
+        return scoped_cmd
+    end
+    merged_env = copy(ENV)
+    for kv in cmd.env
+        key, value = split(kv, "="; limit=2)
+        merged_env[key] = value
+    end
+    return setenv(scoped_cmd, merged_env)
+end
+
 function uidmap_size(map_path::String, username::String = ENV["USER"])
     for line in readlines(map_path)
         try
@@ -299,14 +395,6 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
         rw_maps["/var/run/docker.sock"] = docker_socket_path
     end
 
-    entrypoint = nothing
-    if brg.num_cpus > 0
-        # Mount in the cgroup wrapper script, and the cgroup directory itself
-        ro_maps["/usr/lib/entrypoint"] = joinpath(@__DIR__, "cgroup_wrapper.sh")
-        rw_maps["/usr/lib/cpuset/self"] = "/sys/fs/cgroup/cpuset/$(agent_name)"
-        entrypoint = "/usr/lib/entrypoint"
-    end
-
     return SandboxConfig(
         ro_maps,
         rw_maps,
@@ -319,8 +407,6 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
         # gid=Sandbox.getgid(),
         verbose=verbose,
         multiarch=[brg.platform],
-        # We provide an entrypoint if we need to do some cpuset wrapper setup
-        entrypoint,
     )
 end
 
@@ -468,6 +554,10 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::
             push!(start_pre_hooks, SystemdTarget("$(cg_path) $(agent_name)"))
         end
 
+        if brg.num_cpus > 0
+            c = wrap_command_in_cgroup(agent_name, c)
+        end
+
         systemd_config = SystemdConfig(;
             description="Sandboxed Buildkite agent $(agent_name)",
             working_dir="~",
@@ -544,7 +634,15 @@ function debug_shell(brg::BuildkiteRunnerGroup;
 
         with_executor(UnprivilegedUserNamespacesExecutor; exe_kwargs...) do exe
             exe.persistence_dir = persistence_dir(brg, agent_name)
-            run(exe, config, `/bin/bash -l`)
+            user_cmd = `/bin/bash -l`
+            sandbox_cmd = Sandbox.build_executor_command(exe, config, user_cmd)
+            if brg.num_cpus > 0
+                sandbox_cmd = wrap_command_in_cgroup(agent_name, sandbox_cmd)
+                if !running_under_user_service_scope()
+                    sandbox_cmd = wrap_command_in_user_service_scope(sandbox_cmd)
+                end
+            end
+            run(sandbox_cmd)
         end
     finally
         if docker_proc !== nothing

--- a/linux-sandbox.jl/host_cgroup_wrapper.sh
+++ b/linux-sandbox.jl/host_cgroup_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+join_file="$1"
+shift
+
+echo "$$" > "$join_file"
+exec "$@"

--- a/linux-sandbox.jl/mk_cgroup.c
+++ b/linux-sandbox.jl/mk_cgroup.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <limits.h>
 #include <linux/limits.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -9,8 +10,15 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <stdint.h>
 
 #define min(x, y)       ((x) < (y) ? (x) : (y))
+
+typedef enum {
+    CGROUP_MODE_UNKNOWN = 0,
+    CGROUP_MODE_V1,
+    CGROUP_MODE_V2,
+} cgroup_mode_t;
 
 /* Like assert, but don't go away with optimizations */
 static void _check(int ok, int line) {
@@ -33,6 +41,7 @@ static void mkpath(const char * dir) {
     // clobbers its input, so we copy to a temporary variable first. >:|
     char dir_dirname[PATH_MAX];
     strncpy(dir_dirname, dir, PATH_MAX - 1);
+    dir_dirname[PATH_MAX - 1] = '\0';
     mkpath(dirname(&dir_dirname[0]));
 
     // then create our directory
@@ -56,7 +65,8 @@ static int chown_r(const char * path, uid_t uid, gid_t gid) {
         snprintf(leaf_path, sizeof(leaf_path), "%s/%s", path, entry->d_name);
         check(chown(leaf_path, uid, gid) == 0);
 
-        if (entry->d_type == DT_DIR) {
+        struct stat entry_sb;
+        if (stat(leaf_path, &entry_sb) == 0 && S_ISDIR(entry_sb.st_mode)) {
             if (chown_r(leaf_path, uid, gid) != 0) {
                 return 1;
             }
@@ -67,10 +77,306 @@ static int chown_r(const char * path, uid_t uid, gid_t gid) {
     return 0;
 }
 
-static int verify_cgroup(const char * name, uid_t uid, gid_t gid, const char * cpus) {
+static int read_contents(const char *path, char *buff, size_t buff_size) {
+    int fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        return -1;
+    }
+    int bytes_read = read(fd, buff, buff_size);
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return bytes_read;
+}
+
+static int write_contents(const char *path, const char *buff, size_t buff_size) {
+    int fd = open(path, O_WRONLY);
+    if (fd == -1) {
+        return -1;
+    }
+    ssize_t bytes_written = write(fd, buff, buff_size);
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    if (bytes_written != (ssize_t) buff_size) {
+        return -1;
+    }
+    return 0;
+}
+
+static int append_path_component(char *path, size_t path_size, const char *component) {
+    size_t path_len = strlen(path);
+    size_t component_len = strlen(component);
+    int needs_slash = path_len > 0 && path[path_len - 1] != '/';
+    size_t needed = path_len + (needs_slash ? 1 : 0) + component_len + 1;
+    if (needed > path_size) {
+        return 1;
+    }
+    if (needs_slash) {
+        path[path_len++] = '/';
+    }
+    memcpy(path + path_len, component, component_len + 1);
+    return 0;
+}
+
+static int string_contains_token(const char *text, int text_len, const char *token) {
+    size_t token_len = strlen(token);
+    int idx = 0;
+    while (idx < text_len) {
+        while (idx < text_len && (text[idx] == ' ' || text[idx] == '\n' || text[idx] == '\t')) {
+            idx++;
+        }
+        int start = idx;
+        while (idx < text_len && text[idx] != ' ' && text[idx] != '\n' && text[idx] != '\t') {
+            idx++;
+        }
+        int end = idx;
+        if ((size_t) (end - start) == token_len && strncmp(text + start, token, token_len) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static cgroup_mode_t detect_cgroup_mode(void) {
+    if (access("/sys/fs/cgroup/cgroup.controllers", R_OK) == 0) {
+        return CGROUP_MODE_V2;
+    }
+
+    struct stat sb;
+    if (stat("/sys/fs/cgroup/cpuset", &sb) == 0 && S_ISDIR(sb.st_mode)) {
+        return CGROUP_MODE_V1;
+    }
+
+    return CGROUP_MODE_UNKNOWN;
+}
+
+static int copy_string(char *dst, size_t dst_size, const char *src) {
+    int n = snprintf(dst, dst_size, "%s", src);
+    return n > 0 && (size_t) n < dst_size;
+}
+
+static int has_subtree_control_file(const char *cgroup_path) {
+    char subtree_control_path[PATH_MAX];
+    int n = snprintf(subtree_control_path, sizeof(subtree_control_path), "%s/cgroup.subtree_control", cgroup_path);
+    if (n <= 0 || (size_t) n >= sizeof(subtree_control_path)) {
+        return 0;
+    }
+
+    struct stat sb;
+    if (stat(subtree_control_path, &sb) != 0) {
+        return 0;
+    }
+    return S_ISREG(sb.st_mode);
+}
+
+static int resolve_v2_cgroup_root(uid_t uid, char *path, size_t path_size) {
+    char user_service_path[PATH_MAX];
+    snprintf(user_service_path, sizeof(user_service_path),
+             "/sys/fs/cgroup/user.slice/user-%ju.slice/user@%ju.service",
+             (uintmax_t) uid, (uintmax_t) uid);
+    struct stat sb;
+    if (stat(user_service_path, &sb) == 0 && S_ISDIR(sb.st_mode) && has_subtree_control_file(user_service_path)) {
+        return copy_string(path, path_size, user_service_path) ? 0 : 1;
+    }
+
+    // Fallback to this process's own cgroup path.
+    FILE *f = fopen("/proc/self/cgroup", "r");
+    if (!f) {
+        return 1;
+    }
+    char line[PATH_MAX];
+    while (fgets(line, sizeof(line), f) != NULL) {
+        if (strncmp(line, "0::", 3) == 0) {
+            char *cgroup_path = line + 3;
+            size_t len = strlen(cgroup_path);
+            while (len > 0 && (cgroup_path[len - 1] == '\n' || cgroup_path[len - 1] == '\r')) {
+                cgroup_path[len - 1] = '\0';
+                len--;
+            }
+            if (len == 0) {
+                break;
+            }
+            if (strcmp(cgroup_path, "/") == 0) {
+                fclose(f);
+                if (has_subtree_control_file("/sys/fs/cgroup")) {
+                    return copy_string(path, path_size, "/sys/fs/cgroup") ? 0 : 1;
+                }
+                return 1;
+            }
+
+            char candidate[PATH_MAX];
+            int n = snprintf(candidate, sizeof(candidate), "/sys/fs/cgroup%s", cgroup_path);
+            fclose(f);
+            if (n <= 0 || (size_t) n >= sizeof(candidate)) {
+                return 1;
+            }
+            if (has_subtree_control_file(candidate)) {
+                return copy_string(path, path_size, candidate) ? 0 : 1;
+            }
+
+            // If our current cgroup is a leaf without delegation files,
+            // fall back to the unified root as a last resort.
+            if (has_subtree_control_file("/sys/fs/cgroup")) {
+                return copy_string(path, path_size, "/sys/fs/cgroup") ? 0 : 1;
+            }
+            return 1;
+        }
+    }
+    fclose(f);
+    return 1;
+}
+
+static int resolve_cgroup_root(cgroup_mode_t mode, uid_t uid, char *path, size_t path_size) {
+    if (mode == CGROUP_MODE_V1) {
+        return copy_string(path, path_size, "/sys/fs/cgroup/cpuset") ? 0 : 1;
+    }
+    return resolve_v2_cgroup_root(uid, path, path_size);
+}
+
+static int ensure_v2_cpuset_enabled(const char *cgroup_root) {
+    char relative_root[PATH_MAX];
+    if (strncmp(cgroup_root, "/sys/fs/cgroup", strlen("/sys/fs/cgroup")) != 0) {
+        fprintf(stderr, "Unexpected cgroup root: %s\n", cgroup_root);
+        return 1;
+    }
+
+    if (!copy_string(relative_root, sizeof(relative_root), cgroup_root + strlen("/sys/fs/cgroup"))) {
+        return 1;
+    }
+
+    char current_path[PATH_MAX];
+    if (!copy_string(current_path, sizeof(current_path), "/sys/fs/cgroup")) {
+        return 1;
+    }
+
+    char *remaining = relative_root;
+    while (remaining[0] == '/') {
+        remaining++;
+    }
+
+    while (1) {
+        char controllers_path[PATH_MAX];
+        int n = snprintf(controllers_path, sizeof(controllers_path), "%s/cgroup.controllers", current_path);
+        if (n <= 0 || (size_t) n >= sizeof(controllers_path)) {
+            return 1;
+        }
+
+        char controllers[512];
+        int controllers_len = read_contents(controllers_path, controllers, sizeof(controllers));
+        if (controllers_len <= 0) {
+            return 1;
+        }
+        if (!string_contains_token(controllers, controllers_len, "cpuset")) {
+            fprintf(stderr, "cpuset controller is unavailable at %s\n", current_path);
+            return 1;
+        }
+
+        char subtree_control_path[PATH_MAX];
+        n = snprintf(subtree_control_path, sizeof(subtree_control_path), "%s/cgroup.subtree_control", current_path);
+        if (n <= 0 || (size_t) n >= sizeof(subtree_control_path)) {
+            return 1;
+        }
+
+        char subtree_control[512];
+        int subtree_len = read_contents(subtree_control_path, subtree_control, sizeof(subtree_control));
+        if (subtree_len < 0 && errno == ENOENT) {
+            fprintf(stderr, "cgroup.subtree_control does not exist at %s\n", subtree_control_path);
+            return 1;
+        }
+
+        if (subtree_len <= 0 || !string_contains_token(subtree_control, subtree_len, "cpuset")) {
+            if (write_contents(subtree_control_path, "+cpuset", strlen("+cpuset")) != 0) {
+                perror("Unable to enable cpuset in cgroup.subtree_control");
+                return 1;
+            }
+        }
+
+        if (remaining[0] == '\0') {
+            return 0;
+        }
+
+        char *separator = strchr(remaining, '/');
+        if (separator != NULL) {
+            *separator = '\0';
+        }
+        if (append_path_component(current_path, sizeof(current_path), remaining) != 0) {
+            return 1;
+        }
+        if (separator == NULL) {
+            remaining += strlen(remaining);
+        } else {
+            remaining = separator + 1;
+        }
+        while (remaining[0] == '/') {
+            remaining++;
+        }
+    }
+}
+
+static int read_parent_mems(cgroup_mode_t mode, const char *root, char *buff, size_t buff_size) {
+    char path[PATH_MAX];
+    if (mode == CGROUP_MODE_V1) {
+        int n = snprintf(path, sizeof(path), "%s/cpuset.mems", root);
+        if (n <= 0 || (size_t) n >= sizeof(path)) {
+            return -1;
+        }
+        return read_contents(path, buff, buff_size);
+    }
+
+    int n = snprintf(path, sizeof(path), "%s/cpuset.mems", root);
+    if (n <= 0 || (size_t) n >= sizeof(path)) {
+        return -1;
+    }
+    int bytes_read = read_contents(path, buff, buff_size);
+    if (bytes_read > 0) {
+        return bytes_read;
+    }
+    n = snprintf(path, sizeof(path), "%s/cpuset.mems.effective", root);
+    if (n <= 0 || (size_t) n >= sizeof(path)) {
+        return -1;
+    }
+    bytes_read = read_contents(path, buff, buff_size);
+    if (bytes_read > 0) {
+        return bytes_read;
+    }
+
+    // On some systems, delegated roots may not expose cpuset.mems directly
+    // until parent delegation is complete. Fall back to the parent cgroup.
+    char parent[PATH_MAX];
+    strncpy(parent, root, sizeof(parent) - 1);
+    parent[sizeof(parent) - 1] = '\0';
+    char *parent_dir = dirname(parent);
+    n = snprintf(path, sizeof(path), "%s/cpuset.mems", parent_dir);
+    if (n > 0 && (size_t) n < sizeof(path)) {
+        bytes_read = read_contents(path, buff, buff_size);
+        if (bytes_read > 0) {
+            return bytes_read;
+        }
+    }
+    n = snprintf(path, sizeof(path), "%s/cpuset.mems.effective", parent_dir);
+    if (n > 0 && (size_t) n < sizeof(path)) {
+        bytes_read = read_contents(path, buff, buff_size);
+        if (bytes_read > 0) {
+            return bytes_read;
+        }
+    }
+
+    // Last resort for v2 hierarchy.
+    return read_contents("/sys/fs/cgroup/cpuset.mems.effective", buff, buff_size);
+}
+
+static const char * process_join_file(cgroup_mode_t mode) {
+    if (mode == CGROUP_MODE_V1) {
+        return "tasks";
+    }
+    return "cgroup.procs";
+}
+
+static int verify_cgroup(cgroup_mode_t mode, const char *root, const char * name, uid_t uid, gid_t gid, const char * cpus) {
     // First, check if the directory exists:
     char path[PATH_MAX];
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s", name);
+    snprintf(path, sizeof(path), "%s/%s", root, name);
     struct stat sb;
     if (stat(path, &sb) != 0 || !S_ISDIR(sb.st_mode)) {
         return 1;
@@ -81,15 +387,21 @@ static int verify_cgroup(const char * name, uid_t uid, gid_t gid, const char * c
         return 1;
     }
 
-    // Ensure the assigned cpus are correct
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.cpus", name);
-    int fd = open(path, O_RDONLY);
-    if (fd == -1) {
+    // Ensure the file used for process attachment has expected ownership too.
+    // Without this, stale cgroups created under an older ownership model can
+    // pass verification while still rejecting writes from inside the sandbox.
+    snprintf(path, sizeof(path), "%s/%s/%s", root, name, process_join_file(mode));
+    if (stat(path, &sb) != 0) {
         return 1;
     }
+    if (sb.st_uid != uid || sb.st_gid != gid) {
+        return 1;
+    }
+
+    // Ensure the assigned cpus are correct
+    snprintf(path, sizeof(path), "%s/%s/cpuset.cpus", root, name);
     char buff[128];
-    int bytes_read = read(fd, buff, sizeof(buff));
-    close(fd);
+    int bytes_read = read_contents(path, buff, sizeof(buff));
     if (bytes_read <= 0) {
         return 1;
     }
@@ -98,28 +410,18 @@ static int verify_cgroup(const char * name, uid_t uid, gid_t gid, const char * c
     }
 
     // Ensure the assigned mems are correct
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.mems", name);
-    fd = open(path, O_RDONLY);
-    if (fd == -1) {
-        return 1;
-    }
-    bytes_read = read(fd, buff, sizeof(buff));
-    close(fd);
+    snprintf(path, sizeof(path), "%s/%s/cpuset.mems", root, name);
+    bytes_read = read_contents(path, buff, sizeof(buff));
     if (bytes_read <= 0) {
         return 1;
     }
 
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/cpuset.mems");
-    fd = open(path, O_RDONLY);
-    if (fd == -1) {
-        return 1;
-    }
     char true_mems[128];
-    bytes_read = read(fd, true_mems, sizeof(true_mems));
-    if (bytes_read <= 0) {
+    int true_mems_len = read_parent_mems(mode, root, true_mems, sizeof(true_mems));
+    if (true_mems_len <= 0) {
         return 1;
     }
-    if (strncmp(true_mems, buff, bytes_read) != 0) {
+    if (strncmp(true_mems, buff, min(true_mems_len, bytes_read)) != 0) {
         return 1;
     }
 
@@ -137,47 +439,55 @@ int main(int argc, char * argv[]) {
     uid_t uid = getuid();
     gid_t gid = getgid();
 
-    if (verify_cgroup(name, uid, gid, cpus) == 0) {
+    cgroup_mode_t mode = detect_cgroup_mode();
+    if (mode == CGROUP_MODE_UNKNOWN) {
+        fprintf(stderr, "Unable to detect cgroup mode; expected v1 cpuset or unified v2\n");
+        return 1;
+    }
+
+    char root[PATH_MAX];
+    check(resolve_cgroup_root(mode, uid, root, sizeof(root)) == 0);
+
+    if (mode == CGROUP_MODE_V2) {
+        check(ensure_v2_cpuset_enabled(root) == 0);
+    }
+
+    if (verify_cgroup(mode, root, name, uid, gid, cpus) == 0) {
         // We can exit out immediately without doing anything
         return 0;
     }
 
     // First, create the cpuset
     char path[PATH_MAX];
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s", name);
+    snprintf(path, sizeof(path), "%s/%s", root, name);
     mkpath(path);
 
     // Chown it (recursively) to the appropriate user
     check(chown_r(path, uid, gid) == 0);
 
+    // Copy from the global mems
+    char mems_contents[128];
+    int mems_contents_len = read_parent_mems(mode, root, mems_contents, sizeof(mems_contents));
+    check(mems_contents_len > 0);
+    check(mems_contents_len <= sizeof(mems_contents));
+
+    // Into our new mems (must be set before cpuset.cpus on cgroup v2)
+    snprintf(path, sizeof(path), "%s/%s/cpuset.mems", root, name);
+    check(write_contents(path, mems_contents, mems_contents_len) == 0);
+
     // Next, assign the appropriate cpus to it
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.cpus", name);
+    snprintf(path, sizeof(path), "%s/%s/cpuset.cpus", root, name);
     int fd = open(path, O_WRONLY);
-    if (fd == -1) {
-        fprintf(stderr, "%s not found, ensure you're running with cgroups v1!\n", path);
+    if (fd == -1 && mode == CGROUP_MODE_V1) {
+        fprintf(stderr, "%s not found, ensure cpuset cgroup v1 is mounted!\n", path);
+    } else if (fd == -1 && mode == CGROUP_MODE_V2) {
+        fprintf(stderr, "%s not found, ensure cpuset controller is enabled on cgroup v2!\n", path);
     }
     check(fd != -1);
     check(write(fd, cpus, strlen(cpus)) == strlen(cpus));
     check(close(fd) == 0);
 
-    // Copy from the global mems
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/cpuset.mems");
-    fd = open(path, O_RDONLY);
-    check(fd != -1);
-    char mems_contents[128];
-    int mems_contents_len = read(fd, mems_contents, sizeof(mems_contents));
-    check(mems_contents_len > 0);
-    check(mems_contents_len <= sizeof(mems_contents));
-    check(close(fd) == 0);
-
-    // Into our new mems
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/cpuset/%s/cpuset.mems", name);
-    fd = open(path, O_WRONLY);
-    check(fd != -1);
-    check(write(fd, mems_contents, mems_contents_len) == mems_contents_len);
-    check(close(fd) == 0);
-
     // Verify to ensure that everything went well
-    check(verify_cgroup(name, uid, gid, cpus) == 0);
+    check(verify_cgroup(mode, root, name, uid, gid, cpus) == 0);
     return 0;
  }


### PR DESCRIPTION
Detect the host cgroup layout at runtime and teach the linux sandbox helpers how to create, verify, and join CPU-constrained cgroups on both legacy cpuset hierarchies and unified cgroup v2 systems.

On cgroup v1, keep using /sys/fs/cgroup/cpuset/<agent>, populate cpuset.mems before cpuset.cpus, and join the leaf through the tasks file.  On cgroup v2, resolve a writable delegated root from user@UID.service or the current unified hierarchy, enable cpuset along the subtree_control chain, derive memory nodes from the nearest readable cpuset.mems(.effective), and join the leaf through cgroup.procs.

Also stop trying to move sandboxed processes into the cgroup from inside the container.  Instead, create the cgroup on the host and wrap the sandbox launcher in a small host-side helper that joins the target cgroup before exec.  For interactive debug shells started from a terminal session scope, re-exec through systemd-run --user --scope first so the launcher is already inside user@UID.service and the cgroup move is accepted by the kernel.