### PR TITLE
Split into build and test queue.

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -7,7 +7,8 @@ struct BuildkiteRunnerGroup
     # Number of agents to spawn
     num_agents::Int
 
-    # All the queues this runner will subscribe to
+    # The queue this runner will subscribe to (exactly one; Buildkite cluster
+    # agents cannot listen to multiple queues)
     queues::Set{String}
 
     # Any extra tags to be applied
@@ -45,6 +46,11 @@ end
 
 function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{String,String} = Dict{String,String}())
     queues = Set(filter(!isempty, strip.(split(get(config, "queues", "default"), ","))))
+    # Buildkite cluster agents can only listen to a single queue; fail at config
+    # parse time rather than as an agent that silently can't connect.
+    if length(queues) != 1
+        throw(ArgumentError("Runner group '$(name)' must specify exactly one queue, got: '$(get(config, "queues", "default"))'"))
+    end
     num_agents = get(config, "num_agents", 1)
     tags = get(config, "tags", Dict{String,String}())
     start_rootless_docker = get(config, "start_rootless_docker", false)

--- a/freebsd-kvm/buildkite-worker/config.toml.example
+++ b/freebsd-kvm/buildkite-worker/config.toml.example
@@ -1,10 +1,19 @@
-# We define groups of workers by name, each with their own configuration:
-[freebsd13]
-# Note that `queue` is a comma-separated list of queues
-queues="default"
+# We define groups of workers by name, each with their own configuration.
+# Cluster agents can only listen to a single queue, so a machine that should
+# serve both the `build` and `test` queues defines one group per queue.
+[freebsd13-builder]
+queues="build"
+num_agents=1
+num_cpus=8
+
+[freebsd13-builder.tags]
+# Manually override this to say `freebsd`, even though we're on a linux host
+os="freebsd"
+
+[freebsd13-tester]
+queues="test"
 num_agents=2
 num_cpus=8
 
-[freebsd13.tags]
-# Manually override this to say `freebsd`, even though we're on a linux host
+[freebsd13-tester.tags]
 os="freebsd"

--- a/linux-sandbox.jl/config.toml.example
+++ b/linux-sandbox.jl/config.toml.example
@@ -1,7 +1,16 @@
-# We define groups of workers by name, each with their own configuration:
-[default]
-# Note that `queue` is a comma-separated list of queues
-queues="julia,juliaecosystem"
+# We define groups of workers by name, each with their own configuration.
+# Cluster agents can only listen to a single queue, so a machine that should
+# serve both the `build` and `test` queues defines one group per queue.
+[builder]
+queues="build"
+num_agents=1
+
+[builder.tags]
+sandbox_capable="true"
+cryptic_capable="true"
+
+[tester]
+queues="test"
 num_agents=4
 
 # If you add num_cpus here, it will create a cgroup to limit which
@@ -12,24 +21,22 @@ num_cpus=16
 # If you want agents to be able to share a cache directory, you can
 # add it here.  Use `@scratch/` to place inside of a scratchspace,
 # otherwise use an absolute path.
-sharedcache="@scratch/default_group"
+sharedcache="@scratch/tester_group"
 
 # We can add arbitrary tags here
-[default.tags]
+[tester.tags]
 sandbox_capable="true"
-cryptic_capable="true"
 foo="bar"
 baz="qux"
 
 
-# We can have multiple worker groups, these will all get a rootless docker instance
-# started, one for each buildkite agent instance, and cleared out after each run.
+# Worker groups can also get a rootless docker instance started, one for
+# each buildkite agent instance, cleared out after each run.
 [docker-enabled]
-queues="default,docker"
+queues="test"
 start_rootless_docker=true
 num_agents=2
 
 [docker-enabled.tags]
 docker_capable="true"
-cryptic_capable="true"
 sandbox_capable="true"

--- a/macos-seatbelt/config.toml.example
+++ b/macos-seatbelt/config.toml.example
@@ -1,7 +1,12 @@
-[default]
-queues="julia"
+# Cluster agents can only listen to a single queue, so a machine that should
+# serve both the `build` and `test` queues defines one group per queue.
+[builder]
+queues="build"
 num_agents=1
 
-[default.tags]
+[builder.tags]
 cryptic_capable="true"
 
+[tester]
+queues="test"
+num_agents=1

--- a/windows-kvm/buildkite-worker/config.toml.example
+++ b/windows-kvm/buildkite-worker/config.toml.example
@@ -1,13 +1,23 @@
-# We define groups of workers by name, each with their own configuration:
-[win2k22]
-# Note that `queue` is a comma-separated list of queues
-queues="default"
-num_agents=2
+# We define groups of workers by name, each with their own configuration.
+# Cluster agents can only listen to a single queue, so a machine that should
+# serve both the `build` and `test` queues defines one group per queue.
+[win2k22-builder]
+queues="build"
+num_agents=1
 num_cpus=8
 
 # source_image can be either `standard` or `core`
 source_image="standard"
 
-[win2k22.tags]
+[win2k22-builder.tags]
 # Manually override this to say `windows`, even though we're on a linux host
+os="windows"
+
+[win2k22-tester]
+queues="test"
+num_agents=2
+num_cpus=8
+source_image="standard"
+
+[win2k22-tester.tags]
 os="windows"


### PR DESCRIPTION
Counterpart of https://github.com/JuliaCI/julia-buildkite/pull/543

@fredrikekre Do the Windows VMs cope with being launched with different number of CPUs? If so, we should probably mimic the Linux config and have builders launch with 1 CPU and testers with more.