### PR TITLE
KVM workers: configurable disk location + CoW overlays instead of full copies

### DIFF
--- a/common/buildkite_config.jl
+++ b/common/buildkite_config.jl
@@ -58,7 +58,7 @@ function BuildkiteRunnerGroup(name::String, config::Dict; extra_tags::Dict{Strin
     platform = parse(Platform, get(config, "platform", triplet(HostPlatform())))
     source_image = get(config, "source_image", "")
     tempdir_path = get(config, "tempdir", nothing)
-    cache_path = get(config, "cachedir", @get_scratch!("agent-cache"))
+    cache_path = get(config, "cachedir", nothing)
     shared_cache_path = get(config, "sharedcache", nothing)
     persistence_dir = get(config, "persistence_dir", nothing)
     verbose = get(config, "verbose", false)
@@ -127,5 +127,5 @@ function Base.tempdir(brg::BuildkiteRunnerGroup)
     return something(brg.tempdir_path, tempdir())
 end
 
-cachedir(brg::BuildkiteRunnerGroup) = brg.cache_path
+cachedir(brg::BuildkiteRunnerGroup) = something(brg.cache_path, @get_scratch!("agent-cache"))
 persistence_dir(brg::BuildkiteRunnerGroup) = brg.persistence_dir

--- a/freebsd-kvm/buildkite-worker/common.jl
+++ b/freebsd-kvm/buildkite-worker/common.jl
@@ -12,19 +12,23 @@ function agent_pristine_disk_path(agent_hostname::String)
     return joinpath(@__DIR__, "images", agent_hostname, "$(agent_hostname).qcow2")
 end
 
-function agent_scratch_dir(agent_hostname::String)
-    return joinpath(@get_scratch!("agent_build"), agent_hostname)
+# Where the live VM disks are stored.  This can be pointed at a large/fast disk
+# via the `cachedir` key in `config.toml`; VM disk I/O can otherwise easily
+# saturate the filesystem backing the default scratchspace.
+function agent_scratch_dir(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    base = something(brg.cache_path, @get_scratch!("agent_build"))
+    return joinpath(base, agent_hostname)
 end
 
-function agent_scratch_disk_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).qcow2")
+function agent_scratch_disk_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).qcow2")
 end
-function agent_timestamp_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).timestamp")
+function agent_timestamp_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).timestamp")
 end
 
-function agent_scratch_xml_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).xml")
+function agent_scratch_xml_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).xml")
 end
 
 
@@ -111,7 +115,7 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
                                  agent_hostname::String=string(brg.name, "-%i"),
                                  kwargs...)
     start_pre_hooks = SystemdTarget[
-        SystemdBashTarget("mkdir -p $(agent_scratch_dir(agent_hostname))")
+        SystemdBashTarget("mkdir -p $(agent_scratch_dir(brg, agent_hostname))")
     ]
 
     # If we have buildkite queues, we automatically make this an ephemeral VM
@@ -121,30 +125,32 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
             # Copy our cache image, but only if our OS disk was updated
             SystemdBashTarget(join([
                 # If the buildkite-agent pristine disk image is newer than our timestamp sentinel file
-                "[ $(agent_pristine_disk_path(agent_hostname)) -nt $(agent_timestamp_path(agent_hostname)) ]",
+                "[ $(agent_pristine_disk_path(agent_hostname)) -nt $(agent_timestamp_path(brg, agent_hostname)) ]",
                 # Then copy over our cache disk (since it was also re-created)
-                "cp $(agent_pristine_disk_path(agent_hostname))-1 $(agent_scratch_dir(agent_hostname))/",
+                "cp $(agent_pristine_disk_path(agent_hostname))-1 $(agent_scratch_dir(brg, agent_hostname))/",
                 # Also update our timestamp path
-                "touch $(agent_timestamp_path(agent_hostname))",
+                "touch $(agent_timestamp_path(brg, agent_hostname))",
             ], " && "), [:IgnoreExitCode]),
 
-            # Copy our pristine image to our scratchspace, overwiting the one that already exists, always.
-            SystemdBashTarget("cp $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(agent_hostname))/"),
+            # Recreate our OS disk as a fresh copy-on-write overlay on top of the
+            # pristine image; near-instantaneous, unlike a full copy, while still
+            # guaranteeing that every boot starts from a pristine disk.
+            SystemdBashTarget("qemu-img create -f qcow2 -F qcow2 -b $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_disk_path(brg, agent_hostname))"),
         ])
     else
         # If we're not a buildkite agent, we don't want to reset completely after every reboot
         append!(start_pre_hooks, SystemdTarget[
             # Copy our pristine image to our scratchspace, overwiting the one that already exists, but only if it was updated
-            SystemdBashTarget("cp -u $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(agent_hostname))/", [:IgnoreExitCode]),
+            SystemdBashTarget("cp -u $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(brg, agent_hostname))/", [:IgnoreExitCode]),
         ])
     end
 
     append!(start_pre_hooks, SystemdTarget[
         # Template out our `.xml` configuration file
-        SystemdBashTarget(template_kvm_config_command(agent_hostname; num_cpus=brg.num_cpus)),
+        SystemdBashTarget(template_kvm_config_command(brg, agent_hostname; num_cpus=brg.num_cpus)),
 
         # Start up the virsh domain
-        SystemdBashTarget("virsh create $(agent_scratch_xml_path(agent_hostname))"),
+        SystemdBashTarget("virsh create $(agent_scratch_xml_path(brg, agent_hostname))"),
     ])
 
     stop_post_hooks = SystemdTarget[
@@ -173,23 +179,25 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
     )
     write(io, systemd_config)
 
-    # We only have to do an apparmor check for backing images, for some reason
-    #apparmor_check(agent_scratch_dir(agent_hostname))
-    #apparmor_check(joinpath(@__DIR__, "images"))
+    # We only have to do an apparmor check for backing images; since the OS disk
+    # is an overlay backed by the pristine image (itself backed by the base
+    # image), both of those locations need to be readable by qemu.
+    apparmor_check(agent_scratch_dir(brg, agent_hostname))
+    apparmor_check(joinpath(@__DIR__, "images"))
     apparmor_check(joinpath(dirname(@__DIR__), "base-image", "images"))
 end
 
-function template_kvm_config_command(agent_hostname::String;
+function template_kvm_config_command(brg::BuildkiteRunnerGroup, agent_hostname::String;
                                      num_cpus::Int = 8,
                                      memory_kb::Int = num_cpus*4*1024*1024)
     template = joinpath(@__DIR__, "kvm_machine.xml.template")
-    target = agent_scratch_xml_path(agent_hostname)
+    target = agent_scratch_xml_path(brg, agent_hostname)
 
     mappings = Dict(
         "agent_hostname" => agent_hostname,
         "num_cpus" => num_cpus,
         "memory_kb" => memory_kb,
-        "agent_scratch_dir" => agent_scratch_dir(agent_hostname),
+        "agent_scratch_dir" => agent_scratch_dir(brg, agent_hostname),
         # Use the `h` variable defined as part of the command below
         "agent_mac_address" => "52:54:00:\$\${h:0:2}:\$\${h:2:2}:\$\${h:4:2}",
     )

--- a/freebsd-kvm/buildkite-worker/config.toml.example
+++ b/freebsd-kvm/buildkite-worker/config.toml.example
@@ -6,6 +6,13 @@ queues="build"
 num_agents=1
 num_cpus=8
 
+# Where the live VM disks (and their .xml definitions) are stored; defaults to
+# a Scratch.jl scratchspace in the launching user's home directory.  Point this
+# at a disk that can handle the combined write load of all VMs.  When using a
+# non-default location, also add `<cachedir>/** rk,` to
+# /etc/apparmor.d/local/abstractions/libvirt-qemu on AppArmor-enabled hosts.
+#cachedir="/data/agent_build"
+
 [freebsd13-builder.tags]
 # Manually override this to say `freebsd`, even though we're on a linux host
 os="freebsd"

--- a/windows-kvm/buildkite-worker/Makefile
+++ b/windows-kvm/buildkite-worker/Makefile
@@ -11,4 +11,4 @@ clean:
 	rm -rf images
 
 distclean: clean down
-	rm -rf ~/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent_build/win2k22*
+	@julia --project -e 'include("common.jl"); for brg in read_configs(), idx in 0:(brg.num_agents-1); rm(agent_scratch_dir(brg, get_agent_hostname(brg, idx)); recursive=true, force=true); end'

--- a/windows-kvm/buildkite-worker/common.jl
+++ b/windows-kvm/buildkite-worker/common.jl
@@ -15,19 +15,23 @@ function agent_pristine_disk_path(agent_hostname::String)
     return joinpath(@__DIR__, "pub", agent_hostname, "$(agent_hostname).qcow2")
 end
 
-function agent_scratch_dir(agent_hostname::String)
-    return joinpath(@get_scratch!("agent_build"), agent_hostname)
+# Where the live VM disks are stored.  This can be pointed at a large/fast disk
+# via the `cachedir` key in `config.toml`; VM disk I/O can otherwise easily
+# saturate the filesystem backing the default scratchspace.
+function agent_scratch_dir(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    base = something(brg.cache_path, @get_scratch!("agent_build"))
+    return joinpath(base, agent_hostname)
 end
 
-function agent_scratch_disk_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).qcow2")
+function agent_scratch_disk_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).qcow2")
 end
-function agent_timestamp_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).timestamp")
+function agent_timestamp_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).timestamp")
 end
 
-function agent_scratch_xml_path(agent_hostname::String)
-    return joinpath(agent_scratch_dir(agent_hostname), "$(agent_hostname).xml")
+function agent_scratch_xml_path(brg::BuildkiteRunnerGroup, agent_hostname::String)
+    return joinpath(agent_scratch_dir(brg, agent_hostname), "$(agent_hostname).xml")
 end
 
 
@@ -135,7 +139,7 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
                                  agent_hostname::String=string(brg.name, "-%i"),
                                  kwargs...)
     start_pre_hooks = SystemdTarget[
-        SystemdBashTarget("mkdir -p $(agent_scratch_dir(agent_hostname))")
+        SystemdBashTarget("mkdir -p $(agent_scratch_dir(brg, agent_hostname))")
     ]
 
     # If we have buildkite queues, we automatically make this an ephemeral VM
@@ -145,27 +149,29 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
             # Copy our cache image, but only if our OS disk was updated
             SystemdBashTarget(join([
                 # If the buildkite-agent pristine disk image is newer than our timestamp sentinel file
-                "[ $(agent_pristine_disk_path(agent_hostname)) -nt $(agent_timestamp_path(agent_hostname)) ]",
+                "[ $(agent_pristine_disk_path(agent_hostname)) -nt $(agent_timestamp_path(brg, agent_hostname)) ]",
                 # Then copy over our cache disk (since it was also re-created)
-                "cp -v $(agent_pristine_disk_path(agent_hostname))-1 $(agent_scratch_dir(agent_hostname))/",
+                "cp -v $(agent_pristine_disk_path(agent_hostname))-1 $(agent_scratch_dir(brg, agent_hostname))/",
                 # Also update our timestamp path
-                "touch $(agent_timestamp_path(agent_hostname))",
+                "touch $(agent_timestamp_path(brg, agent_hostname))",
             ], " && "), [:IgnoreExitCode]),
 
-            # Copy our pristine image to our scratchspace, overwiting the one that already exists, always.
-            SystemdBashTarget("cp -v $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(agent_hostname))/"),
+            # Recreate our OS disk as a fresh copy-on-write overlay on top of the
+            # pristine image; near-instantaneous, unlike a full copy, while still
+            # guaranteeing that every boot starts from a pristine disk.
+            SystemdBashTarget("qemu-img create -f qcow2 -F qcow2 -b $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_disk_path(brg, agent_hostname))"),
         ])
     else
         # If we're not a buildkite agent, we don't want to reset completely after every reboot
         append!(start_pre_hooks, SystemdTarget[
             # Copy our pristine image to our scratchspace, overwiting the one that already exists, but only if it was updated
-            SystemdBashTarget("cp -u $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(agent_hostname))/", [:IgnoreExitCode]),
+            SystemdBashTarget("cp -u $(agent_pristine_disk_path(agent_hostname)) $(agent_scratch_dir(brg, agent_hostname))/", [:IgnoreExitCode]),
         ])
     end
 
     append!(start_pre_hooks, SystemdTarget[
         # Template out our `.xml` configuration file
-        SystemdBashTarget(template_kvm_config_command(agent_hostname; num_cpus=brg.num_cpus)),
+        SystemdBashTarget(template_kvm_config_command(brg, agent_hostname; num_cpus=brg.num_cpus)),
     ])
 
     stop_post_hooks = SystemdTarget[
@@ -185,7 +191,7 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
 
         exec_start=SystemdBashTarget(join([
             # Start up the virsh domain
-            "virsh create $(agent_scratch_xml_path(agent_hostname))",
+            "virsh create $(agent_scratch_xml_path(brg, agent_hostname))",
             # Handle systemd killing us
             "trap 'virsh shutdown $(agent_hostname)' SIGUSR1",
             # Wait for the VM to stop running
@@ -202,23 +208,25 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup;
     )
     write(io, systemd_config)
 
-    # We only have to do an apparmor check for backing images, for some reason
-    #apparmor_check(agent_scratch_dir(agent_hostname))
-    #apparmor_check(joinpath(@__DIR__, "pub"))
+    # We only have to do an apparmor check for backing images; since the OS disk
+    # is an overlay backed by the pristine image (itself backed by the base
+    # image), both of those locations need to be readable by qemu.
+    apparmor_check(agent_scratch_dir(brg, agent_hostname))
+    apparmor_check(joinpath(@__DIR__, "pub"))
     apparmor_check(joinpath(dirname(@__DIR__), "base-image", "pub"))
 end
 
-function template_kvm_config_command(agent_hostname::String;
+function template_kvm_config_command(brg::BuildkiteRunnerGroup, agent_hostname::String;
                                      num_cpus::Int = 8,
                                      memory_kb::Int = num_cpus*4*1024*1024)
     template = joinpath(@__DIR__, "kvm_machine.xml.template")
-    target = agent_scratch_xml_path(agent_hostname)
+    target = agent_scratch_xml_path(brg, agent_hostname)
 
     mappings = Dict(
         "agent_hostname" => agent_hostname,
         "num_cpus" => num_cpus,
         "memory_kb" => memory_kb,
-        "agent_scratch_dir" => agent_scratch_dir(agent_hostname),
+        "agent_scratch_dir" => agent_scratch_dir(brg, agent_hostname),
         # Use the `h` variable defined as part of the command below
         "agent_mac_address" => "52:54:00:\$\${h:0:2}:\$\${h:2:2}:\$\${h:4:2}",
     )

--- a/windows-kvm/buildkite-worker/config.toml.example
+++ b/windows-kvm/buildkite-worker/config.toml.example
@@ -9,6 +9,13 @@ num_cpus=8
 # source_image can be either `standard` or `core`
 source_image="standard"
 
+# Where the live VM disks (and their .xml definitions) are stored; defaults to
+# a Scratch.jl scratchspace in the launching user's home directory.  Point this
+# at a disk that can handle the combined write load of all VMs.  When using a
+# non-default location, also add `<cachedir>/** rk,` to
+# /etc/apparmor.d/local/abstractions/libvirt-qemu on AppArmor-enabled hosts.
+#cachedir="/data/agent_build"
+
 [win2k22-builder.tags]
 # Manually override this to say `windows`, even though we're on a linux host
 os="windows"


### PR DESCRIPTION
The Windows and FreeBSD KVM workers stored their live VM disks in a Scratch.jl scratchspace under the launching user's home directory, and re-created them on every boot by copying the full pristine image.  On amdci6 this put the combined write load of all VMs (plus a full image copy per VM boot) on the small system SSD, saturating it to the point where the ExecStartPre 'cp' would exceed the 1-minute start timeout and hang in uninterruptible sleep, wedging the agents.

Two changes:

- The VM disk location is now configurable via the existing 'cachedir' config.toml key (previously only honored by the Linux sandbox runners), so it can be pointed at a disk that can take the load. The default remains the same scratchspace as before.

- For ephemeral (queue-serving) agents, the OS disk is now re-created as a qcow2 copy-on-write overlay backed by the pristine image, instead of a full copy.  This is near-instantaneous, writes only deltas, and preserves the boot-from-pristine guarantee.  The pristine images were already overlays backed by the base image, so backing chains (and the corresponding AppArmor rules) are nothing new; the previously-commented-out apparmor_check calls for the pristine image and scratch directories are now enabled since qemu reads through to them.