### PR TITLE
Bump FreeBSD + Windows buildkite-agent to 3.97.1 (OIDC aws session tags)

### DIFF
--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -14,7 +14,7 @@ echo "-> Installing buildkite-agent"
 # We want to install buildkite in the same way as the port so that we can use it as
 # a system service but we want to use buildkite's official binaries and distribution
 # info to ensure consistency with other systems.
-URL="https://github.com/buildkite/agent/releases/download/v3.39.0/buildkite-agent-freebsd-amd64-3.39.0.tar.gz"
+URL="https://github.com/buildkite/agent/releases/download/v3.97.1/buildkite-agent-freebsd-amd64-3.97.1.tar.gz"
 FILENAME="$(basename "${URL}")"
 
 mkdir -p /tmp/buildkite-install

--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -7,7 +7,7 @@ if ($env:buildkiteAgentQueues -eq $null) {
 Write-Output " -> Installing buildkite-agent"
 
 # Note that our `secrets.ps1` file is supposed to set `$env:buildkiteAgentToken` first
-$env:buildkiteAgentUrl = "https://github.com/buildkite/agent/releases/download/v3.82.1/buildkite-agent-windows-amd64-3.82.1.zip"
+$env:buildkiteAgentUrl = "https://github.com/buildkite/agent/releases/download/v3.97.1/buildkite-agent-windows-amd64-3.97.1.zip"
 iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/buildkite/agent/main/install.ps1'))
 
 # Create service to auto-start buildkite


### PR DESCRIPTION
The Julia CI OIDC trust migration (JuliaCI/julia-buildkite#544) requires buildkite-agent's 'oidc request-token --aws-session-tag', which was added in buildkite-agent v3.83.0 (2024-09-24). The FreeBSD (3.39.0) and Windows (3.82.1) workers predate it, so their staging step fails with 'flag provided but not defined: -aws-session-tag' while linux (3.97.1) and macOS (3.103.0) succeed. Bump both to 3.97.1, matching the linux fleet. (FreeBSD already installs py311-awscli; the Windows build container already carries the AWS CLI, and the host agent only needs to mint the token.)