### PR TITLE
Allow jobs to override their nofile ulimit.

### DIFF
--- a/common/linux_systemd_config.jl
+++ b/common/linux_systemd_config.jl
@@ -81,8 +81,9 @@ struct SystemdConfig
     start_timeout::Union{String,Nothing}
     stop_timeout::Union{String,Nothing}
 
-    # Maximum number of open file descriptors
-    limit_nofile::Union{Int,Nothing}
+    # Maximum number of open file descriptors. Either an `Int` (sets soft and hard
+    # alike) or a `"soft:hard"` string, matching systemd's `LimitNOFILE=` syntax.
+    limit_nofile::Union{Int,String,Nothing}
 
     # What the "type" of this systemd config is (e.g. :simple, :forking, etc...)
     type::Symbol

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -576,7 +576,11 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::
             restart=SystemdRestartConfig(),
             start_timeout="1min",
             stop_timeout="120min",
-            limit_nofile=10240,
+            # Soft limit stays at the historical 10240, but allow jobs to raise their
+            # own `ulimit -n` up to the host's hard limit (build scripts often do).
+            # A bare `LimitNOFILE=10240` would pin the *hard* limit too, making any
+            # such `ulimit -n` fail with EPERM.
+            limit_nofile="10240:524288",
             kill_mode="mixed",
             start_pre_hooks,
             exec_start=SystemdTarget(join(c.exec, " ")),


### PR DESCRIPTION
For Yggdrasil, https://github.com/JuliaPackaging/Yggdrasil/blob/378f06789e37d43fdf234c7c5df48cca7bfc002d/.buildkite/build.sh#L30C1-L30C16