### PR TITLE
Improve missing persist dir error.

### DIFF
--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -452,10 +452,30 @@ function persistence_dir(brg, agent_name)
     rootfs_dir = @artifact_str("buildkite-agent-rootfs", brg.platform)
 
     # Once we've found a good persistence root, go into an agent-specific location.
-    return joinpath(
-        Sandbox.find_persist_dir_root(rootfs_dir, persistence_hints)[1],
-        string("persist-", agent_name)
-    )
+    persist_root = Sandbox.find_persist_dir_root(rootfs_dir, persistence_hints)[1]
+    if persist_root === nothing
+        error("""
+            No usable persistence directory: none of the candidate paths are on a
+            filesystem that can host an overlayfs upperdir.
+            Tried (in order): $(join(persistence_hints, ", ")).
+
+            The persistence dir is used as the overlay upper/work dir (see Sandbox.jl),
+            which requires RENAME_WHITEOUT support. zfs, ecryptfs and tmpfs do NOT
+            qualify; ext4/xfs do. Common causes:
+              - the dir lives on a zfs dataset -> give it a dedicated ext4/xfs volume;
+              - an ext4 volume nested under a zfs mountpoint is being *shadowed* by the
+                zfs mount (a boot-time mount-ordering race). Check with:
+                    stat -f -c %T <dir>     # prints the *effective* fs at that path
+                and compare against `mount`/fstab; ensure the ext4 mount is ordered
+                after the zfs mount, or move it out from under the zfs mountpoint.
+
+            Diagnose an upperdir candidate U (with lower L, work W) directly via:
+                unshare --map-root-user --user --mount \\
+                    mount -t overlay overlay -o lowerdir=L,upperdir=U,workdir=W,userxattr /mnt
+                # then `dmesg | tail` -- look for "upper fs does not support RENAME_WHITEOUT"
+            """)
+    end
+    return joinpath(persist_root, string("persist-", agent_name))
 end
 
 function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::String=string(brg.name, "-%i"), kwargs...)


### PR DESCRIPTION
Currently errors with a MethodError for `joinpath(::String, ::Nothing)`.