### PR TITLE
Bump Buildkite agent to v3.127.2.

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,19 +1,56 @@
 [[buildkite-agent]]
 arch = "x86_64"
-git-tree-sha1 = "8b22243fed9a314b766d80458491cf73b005766f"
+git-tree-sha1 = "15118bd950d8f0116bd165134d7e04f8bac96904"
 os = "macos"
 
     [[buildkite-agent.download]]
-    sha256 = "54899b5c0c43d4a6ee25065d443c6ba1faea0022bfc86ab52e7a737817217fc8"
-    url = "https://github.com/buildkite/agent/releases/download/v3.103.0/buildkite-agent-darwin-amd64-3.103.0.tar.gz"
+    sha256 = "cd0e9da824edea14889447865c0dd6bf90651d712915904ddbd572f49c49eb25"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-darwin-amd64-3.127.2.tar.gz"
 [[buildkite-agent]]
 arch = "aarch64"
-git-tree-sha1 = "90baa190031a8cb72887ecad2a4126855670fb92"
+git-tree-sha1 = "cac286e10919e58bc8382d3f92051617b5fd6b55"
 os = "macos"
 
     [[buildkite-agent.download]]
-    sha256 = "d9ad60f24700874089b205871b7e04ae7322e73422752b784914c35bbbd8a7d3"
-    url = "https://github.com/buildkite/agent/releases/download/v3.103.0/buildkite-agent-darwin-arm64-3.103.0.tar.gz"
+    sha256 = "8763418091d622f69b7196487d500aa040b78b77bc5ba0ccbad973a5cdb991e9"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-darwin-arm64-3.127.2.tar.gz"
+[[buildkite-agent]]
+arch = "x86_64"
+git-tree-sha1 = "6358f724a7114f842a2c1507e7e1cc11402e0f12"
+libc = "glibc"
+os = "linux"
+
+    [[buildkite-agent.download]]
+    sha256 = "6a83b8016dabb2d12b2c8651eea5edb8a98dce2700f8888019fc2bc7c5ae13d8"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-linux-amd64-3.127.2.tar.gz"
+[[buildkite-agent]]
+arch = "aarch64"
+git-tree-sha1 = "3fa87cc61ae8277e1dffe348eed6d9055c84edd0"
+libc = "glibc"
+os = "linux"
+
+    [[buildkite-agent.download]]
+    sha256 = "5bc021b783a3be06f0204d19f1374beab079ccd90b0e145958263fa8b6ae069e"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-linux-arm64-3.127.2.tar.gz"
+[[buildkite-agent]]
+arch = "armv7l"
+call_abi = "eabihf"
+git-tree-sha1 = "39250a334adcab0d6e521a62bd2ba1163c71062d"
+libc = "glibc"
+os = "linux"
+
+    [[buildkite-agent.download]]
+    sha256 = "cd279df3a638c0179be58fb920f7f8aba739047defba02e931cb7350171e025c"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-linux-armhf-3.127.2.tar.gz"
+[[buildkite-agent]]
+arch = "powerpc64le"
+git-tree-sha1 = "b4cf67cb26f30b94efc4019448c3c6d5926cadd7"
+libc = "glibc"
+os = "linux"
+
+    [[buildkite-agent.download]]
+    sha256 = "6bff4efcbbde09aa1e5f2e1d83d9fbab4eeffaf1cda278108f381062f61f2f04"
+    url = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-linux-ppc64le-3.127.2.tar.gz"
 
 [[buildkite-agent-rootfs]]
 arch = "armv7l"

--- a/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -14,7 +14,7 @@ echo "-> Installing buildkite-agent"
 # We want to install buildkite in the same way as the port so that we can use it as
 # a system service but we want to use buildkite's official binaries and distribution
 # info to ensure consistency with other systems.
-URL="https://github.com/buildkite/agent/releases/download/v3.97.1/buildkite-agent-freebsd-amd64-3.97.1.tar.gz"
+URL="https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-freebsd-amd64-3.127.2.tar.gz"
 FILENAME="$(basename "${URL}")"
 
 mkdir -p /tmp/buildkite-install
@@ -43,6 +43,9 @@ shell="$(which bash) -c"
 git-fetch-flags="-v --prune --tags"
 disconnect-after-job=true
 disconnect-after-idle-timeout=3600
+# Workaround for delayed disconnect-after-job in streaming ping mode
+# (https://github.com/buildkite/agent/pull/3994)
+ping-mode="poll-only"
 
 # Disable this mirrors path, as github does not seem to respond to us.  :(
 #git-mirrors-path="/cache/repos"

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -351,6 +351,11 @@ function Sandbox.SandboxConfig(brg::BuildkiteRunnerGroup;
         "/hooks" => joinpath(repo_root, "hooks"),
         "/secrets" => secrets_dir(brg),
 
+        # Mount in an up-to-date agent binary (served from our artifact!), rather
+        # than relying on the ancient apt-installed copy baked into the rootfs.
+        # The agent is a statically-linked Go binary, so the bare binary suffices.
+        "/usr/bin/buildkite-agent" => artifact_lookup("buildkite-agent/buildkite-agent"),
+
         # Mount in a machine-id file that will be consistent across runs, but unique to each agent
         "/etc/machine-id" => joinpath(@get_scratch!("agent-cache"), "$(agent_name).machine-id"),
     )
@@ -502,11 +507,14 @@ function generate_systemd_script(io::IO, brg::BuildkiteRunnerGroup; agent_name::
         #    builds against e.g. `HEAD` or `release-1.8` and still get a hash here.
         #  - git-fetch-flags: we need to pull down git tags as well as content, so that
         #    our git versioning scripts can correctly determine when we're sitting on a tag.
+        #  - ping-mode: workaround for delayed disconnect-after-job in streaming ping
+        #    mode (https://github.com/buildkite/agent/pull/3994).
         c = Sandbox.build_executor_command(
             exe,
             config,
             ```/usr/bin/buildkite-agent start
                                 --disconnect-after-job
+                                --ping-mode=poll-only
                                 --hooks-path=/hooks
                                 --build-path=/cache/build
                                 --experiment=resolve-commit-after-checkout

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -201,6 +201,7 @@ function generate_launchctl_script(io::IO, brg::BuildkiteRunnerGroup;
             # Invoke agent inside of sandbox
             sandbox-exec -f $(sb_path) $(agent_path) start \\
                 --disconnect-after-job \\
+                --ping-mode=poll-only \\
                 --sockets-path=$(temp_path) \\
                 --hooks-path=$(hooks_path) \\
                 --build-path=$(cache_path)/build \\
@@ -404,6 +405,7 @@ function run_buildkite_agent(brg::BuildkiteRunnerGroup;
 
         agent_cmd = ```$(agent_path) start
             --disconnect-after-job
+            --ping-mode=poll-only
             --hooks-path=$(hooks_path)
             --build-path=$(cache_path)/build
             --git-mirrors-path=$(cache_path)/repos

--- a/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
+++ b/windows-kvm/buildkite-worker/setup_scripts/0-02-install-buildkite-agent.ps1
@@ -7,7 +7,7 @@ if ($env:buildkiteAgentQueues -eq $null) {
 Write-Output " -> Installing buildkite-agent"
 
 # Note that our `secrets.ps1` file is supposed to set `$env:buildkiteAgentToken` first
-$env:buildkiteAgentUrl = "https://github.com/buildkite/agent/releases/download/v3.97.1/buildkite-agent-windows-amd64-3.97.1.zip"
+$env:buildkiteAgentUrl = "https://github.com/buildkite/agent/releases/download/v3.127.2/buildkite-agent-windows-amd64-3.127.2.zip"
 iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/buildkite/agent/main/install.ps1'))
 
 # Create service to auto-start buildkite
@@ -44,6 +44,10 @@ Add-Content -Path "$bk_config" -Value "shell=`"bash.exe -c`""
 # Disconnect after a job, and after being idle for an hour (to prevent issues from e.g. losing the network adapter)
 Add-Content -Path "$bk_config" -Value "disconnect-after-job=true"
 Add-Content -Path "$bk_config" -Value "disconnect-after-idle-timeout=3600"
+
+# Workaround for delayed disconnect-after-job in streaming ping mode
+# (https://github.com/buildkite/agent/pull/3994)
+Add-Content -Path "$bk_config" -Value "ping-mode=`"poll-only`""
 
 # Fetch git tags as well
 Add-Content -Path "$bk_config" -Value "git-fetch-flags=`"-v --prune --tags`""


### PR DESCRIPTION
Includes the workaround from https://github.com/buildkite/agent/pull/3994

Also uses artifacts for Linux now, so we can get rid of the buildkite agent from the rootfs.