### PR TITLE
Per-group agent numbering

### DIFF
--- a/common/linux_systemd_config.jl
+++ b/common/linux_systemd_config.jl
@@ -305,29 +305,25 @@ function clear_systemd_configs()
 end
 
 function launch_systemd_services(brgs::Vector{BuildkiteRunnerGroup})
-    agent_idx = 0
     # Sort `brgs` by name, for consistent ordering
     brgs = sort(brgs, by=brg -> brg.name)
     for brg in brgs
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             unit_name = systemd_unit_name(brg, agent_idx)
             @info("Launching $(unit_name)")
             run(`sudo systemctl enable $(unit_name)`)
             run(`sudo systemctl start $(unit_name)`)
-            agent_idx += 1
         end
     end
 end
 
 function stop_systemd_services(brgs::Vector{BuildkiteRunnerGroup})
-    agent_idx = 0
     brgs = sort(brgs, by=brg -> brg.name)
     for brg in brgs
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             unit_name = systemd_unit_name(brg, agent_idx)
             run(`sudo systemctl stop $(unit_name)`)
             run(`sudo systemctl disable $(unit_name)`)
-            agent_idx += 1
         end
     end
 end

--- a/common/mac_launchctl_config.jl
+++ b/common/mac_launchctl_config.jl
@@ -32,7 +32,7 @@ function write(io::IO, config::LaunchctlConfig)
     <plist version="1.0"><dict>
     """)
 
-    # Job label, e.g. "org.julialang.buildkite.solstice-default.0"
+    # Job label, e.g. "org.julialang.buildkite.solstice-default.1"
     println(io, """
         <key>Label</key>
         <string>$(config.label)</string>

--- a/freebsd-kvm/buildkite-worker/common.jl
+++ b/freebsd-kvm/buildkite-worker/common.jl
@@ -54,7 +54,6 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
 
     packer_builds = Base.Process[]
 
-    agent_idx = 0
     brgs = sort(brgs, by=brg -> brg.name)
     for brg in brgs
         source_image = joinpath(dirname(@__DIR__), "base-image", "images", "freebsd13.qcow2")
@@ -67,7 +66,7 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
         tags_with_queues = ["$tag=$value" for (tag, value) in brg.tags]
         append!(tags_with_queues, ["queue=$(queue)" for queue in brg.queues])
 
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             agent_hostname = get_agent_hostname(brg, agent_idx)
 
             # First, generate .pkr.hcl file in `build`
@@ -91,8 +90,6 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
                 packer_cmd = `packer build -var-file=$(packer_secrets_file) $(packer_file)`
                 push!(packer_builds, run(pipeline(packer_cmd; stdout, stderr); wait=false))
             end
-
-            agent_idx += 1
         end
     end
 

--- a/linux-sandbox.jl/common.jl
+++ b/linux-sandbox.jl/common.jl
@@ -43,16 +43,14 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
         names_to_cpus = Dict{Vector{String},String}()
         cpu_permutation = cpu_topology_permutation()
         cpu_offset = 0
-        agent_idx = 0
         for brg in brgs
-            for _ in 1:brg.num_agents
+            for agent_idx in 1:brg.num_agents
                 unit_name = systemd_unit_name(brg, agent_idx)
                 if brg.num_cpus > 0
                     names = [string(brg.name, "-", get_short_hostname(), ".", agent_idx), unit_name]
                     names_to_cpus[names] = condense_cpu_selection(cpu_permutation[cpu_offset+1:cpu_offset+brg.num_cpus])
                     cpu_offset += brg.num_cpus
                 end
-                agent_idx += 1
             end
         end
 
@@ -629,13 +627,12 @@ end
 # (the `mk_cgroup` machinery is still used by `debug_shell()`).  `AllowedCPUs=` uses
 # the cpuset controller on cgroup v2; `CPUAffinity=` works everywhere else.
 function generate_cpu_pinning_dropins(brgs::Vector{BuildkiteRunnerGroup})
-    agent_idx = 0
     cpu_permutation = cpu_topology_permutation()
     cpu_offset = 0
     # Sort `brgs` by name, to match the ordering of `launch_systemd_services()`
     brgs = sort(brgs, by=brg -> brg.name)
     for brg in brgs
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             unit_name = systemd_unit_name(brg, agent_idx)
             if brg.num_cpus > 0
                 cpus = condense_cpu_selection(cpu_permutation[cpu_offset+1:cpu_offset+brg.num_cpus])
@@ -648,7 +645,6 @@ function generate_cpu_pinning_dropins(brgs::Vector{BuildkiteRunnerGroup})
                     """)
                 cpu_offset += brg.num_cpus
             end
-            agent_idx += 1
         end
     end
     run(`sudo systemctl daemon-reload`)

--- a/linux-sandbox.jl/debug_shell.jl
+++ b/linux-sandbox.jl/debug_shell.jl
@@ -9,15 +9,13 @@ name_pattern = get(ARGS, 1, configs[1].name)
 
 # Find first agent that matches the given agent_name
 function find_agent_name(name_pattern::AbstractString)
-    agent_idx = 0
     hostname = get_short_hostname()
     for brg in configs
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             agent_name = string(brg.name, "-", hostname, ".", agent_idx)
             if contains(agent_name, name_pattern)
                 return brg, agent_name
             end
-            agent_idx += 1
         end
     end
     return nothing, nothing

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -116,6 +116,12 @@ function check_configs(brgs::Vector{BuildkiteRunnerGroup})
             error("Refusing to start up macOS runner with default tempdir!")
         end
 
+        # The macOS launch path only ever starts a single agent per group, so
+        # `num_agents > 1` would silently drop the extras.
+        if brg.num_agents != 1
+            error("macOS runner group '$(brg.name)' sets num_agents=$(brg.num_agents); only 1 agent per group is supported on macOS!")
+        end
+
         # Auto-fill `macos_version` tag:
         brg.tags["macos_version"] = "$(macos_version.major).$(macos_version.minor)"
     end

--- a/macos-seatbelt/common.jl
+++ b/macos-seatbelt/common.jl
@@ -352,7 +352,7 @@ function force_delete(path)
     rm(path; force=true, recursive=true)
 end
 
-default_agent_name(brg) = string(brg.name, "-", get_short_hostname(), ".0")
+default_agent_name(brg) = string(brg.name, "-", get_short_hostname(), ".1")
 
 function seatbelt_setup(f::Function, brg::BuildkiteRunnerGroup;
                        agent_name::String = default_agent_name(brg),

--- a/windows-kvm/buildkite-worker/common.jl
+++ b/windows-kvm/buildkite-worker/common.jl
@@ -58,7 +58,6 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
     packer_builds = Base.Process[]
     packer_build_hostnames = String[]
 
-    agent_idx = 0
     brgs = sort(brgs, by=brg -> brg.name)
     for brg in brgs
         # Ensure that we have a `source_image` type set
@@ -84,7 +83,7 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
         tags_with_queues = ["$tag=$value" for (tag, value) in brg.tags]
         append!(tags_with_queues, ["queue=$(queue)" for queue in brg.queues])
 
-        for _ in 1:brg.num_agents
+        for agent_idx in 1:brg.num_agents
             agent_hostname = get_agent_hostname(brg, agent_idx)
 
             # First, generate .pkr.hcl file in `build`
@@ -109,8 +108,6 @@ function build_packer_images(brgs::Vector{BuildkiteRunnerGroup})
                 push!(packer_builds, run(pipeline(packer_cmd; stdout, stderr); wait=false))
                 push!(packer_build_hostnames, agent_hostname)
             end
-
-            agent_idx += 1
         end
     end
 


### PR DESCRIPTION
Otherwise adding e.g. a `build` group renames unrelated `test` agents.

Also make it 1-indexed.