### PR TITLE
windows: grow the fixed pagefile from 8GiB to 32GiB

### DIFF
--- a/platforms/windows-kvm/base-image/setup_scripts/3-02-boot-tuning.ps1
+++ b/platforms/windows-kvm/base-image/setup_scripts/3-02-boot-tuning.ps1
@@ -50,13 +50,26 @@ foreach ($tp in $taskpaths) {
 
 # Fixed-size pagefile: avoids per-boot pagefile re-creation and runtime grow
 # stalls (do NOT run pageless: linkers ask for large commit).
-Write-Output " -> Fixing pagefile at 8GiB"
+#
+# Size it for the largest deployment, not for the packer build VM (this script
+# runs with much less RAM than the deployed workers get).  The Julia testers run
+# with 24GiB RAM and their commit budget peaks well past RAM + 8GiB: ~9 test
+# workers are each allowed JULIA_TEST_MAXRSS_MB=3800 before being recycled, and
+# tests like cmdlineargs.jl/compileall.jl additionally spawn full sysimage
+# `--output-o` builds (~5-6GiB commit each) that the RSS recycling never sees.
+# Windows has no overcommit, so once commit charge hits RAM + pagefile,
+# concurrent processes start dying with "LLVM ERROR: out of memory" and
+# ERROR_COMMITMENT_LIMIT ("The paging file is too small for this operation to
+# complete") on DLL loads.  32GiB gives a 24GiB machine a 56GiB commit ceiling,
+# comfortably above that budget, and fits alongside a Julia build tree on the
+# 100GiB OS disk.
+Write-Output " -> Fixing pagefile at 32GiB"
 Set-CimInstance -Query "SELECT * FROM Win32_ComputerSystem" -Property @{AutomaticManagedPagefile=$false}
 $pf = Get-CimInstance -ClassName Win32_PageFileSetting -ErrorAction SilentlyContinue
 if ($pf) {
-    $pf | Set-CimInstance -Property @{InitialSize=8192; MaximumSize=8192}
+    $pf | Set-CimInstance -Property @{InitialSize=32768; MaximumSize=32768}
 } else {
-    New-CimInstance -ClassName Win32_PageFileSetting -Property @{Name="C:\pagefile.sys"; InitialSize=8192; MaximumSize=8192}
+    New-CimInstance -ClassName Win32_PageFileSetting -Property @{Name="C:\pagefile.sys"; InitialSize=32768; MaximumSize=32768}
 }
 
 Write-Output " -> Power tuning"


### PR DESCRIPTION
The win2k22 Julia testers (24GiB RAM) have been sporadically failing with "LLVM ERROR: out of memory" and ERROR_COMMITMENT_LIMIT ("The paging file is too small for this operation to complete") on DLL loads, taking down several test workers at once, e.g. https://buildkite.com/julialang/julia-ci/builds/23#019f29dd-d978-4a88-8393-4e3927decbd6

This is commit-charge exhaustion, not RAM exhaustion: Windows has no overcommit, and the test harness's worst-case commit budget (~9 workers x 3.8GiB soft RSS limit, plus ~5-6GiB sysimage --output-o subprocesses that the RSS-based worker recycling never sees, plus fully-committed task stacks that never show up as RSS) exceeds the 32GiB ceiling that 24GiB RAM + the 8GiB fixed pagefile provides.

Keep the pagefile fixed-size (the original motivation - no per-boot re-creation, no runtime grow stalls - still stands), but size it for the deployed workers instead: 32GiB gives the testers a 56GiB commit ceiling and still fits alongside a Julia build tree on the 100GiB OS disk.

This change was written with the assistance of generative AI (Claude).


Claude-Session: https://claude.ai/code/session_01Wj6T8wDpwFGkjgLKT6kCam