### PR TITLE
Fixes for macOS concurrency

### DIFF
--- a/src/backends/kvm.jl
+++ b/src/backends/kvm.jl
@@ -229,6 +229,12 @@ function check_config(::KVMBackend, brgs::Vector{BuildkiteRunnerGroup})
     return nothing
 end
 
+function backend_available(::KVMBackend, brg::BuildkiteRunnerGroup)
+    return isfile(kvm_pristine_os_image(brg)) &&
+        isfile(kvm_pristine_cache_image(brg)) &&
+        isfile(kvm_xml_template(brg))
+end
+
 function setup_config!(backend::KVMBackend, brgs::Vector{BuildkiteRunnerGroup})
     check_config(backend, brgs)
     if !isempty(brgs)

--- a/src/backends/macos_seatbelt.jl
+++ b/src/backends/macos_seatbelt.jl
@@ -463,17 +463,16 @@ function seatbelt_setup(f::Function, brg::BuildkiteRunnerGroup;
         agent_token_path=agent_token_path,
         julia_arch=brg.tags["arch"],
         alloc)
+    build_path = joinpath(cache_path, "build")
 
     try
-        cd(joinpath(cache_path, "build")) do
-            with_seatbelt(generate_buildkite_seatbelt_config, [cache_path], temp_path) do sb_path
-                if brg.verbose
-                    run(`cat $(sb_path)`)
-                    println()
-                    println()
-                end
-                f(sb_path, seatbelt_env)
+        with_seatbelt(generate_buildkite_seatbelt_config, [cache_path], temp_path) do sb_path
+            if brg.verbose
+                run(`cat $(sb_path)`)
+                println()
+                println()
             end
+            f(sb_path, seatbelt_env, build_path)
         end
     finally
         force_delete.(host_paths_to_cleanup(backend, temp_path, cache_path))
@@ -513,7 +512,7 @@ function run_job(handle::MacSeatbeltHandle, deadline::Union{Nothing,Float64}=not
         cache_path=handle.plan.cache_pool,
         temp_path=handle.temp_path,
         alloc=handle.alloc,
-    ) do sb_path, seatbelt_env
+    ) do sb_path, seatbelt_env, build_path
         # Keep the agent's Unix sockets (e.g. the job-api socket) directly under
         # the short temp dir.  The default is `$HOME/.buildkite-agent/sockets`,
         # which on macOS blows past the 104-character `sun_path` limit and
@@ -529,7 +528,8 @@ function run_job(handle::MacSeatbeltHandle, deadline::Union{Nothing,Float64}=not
 
         open(handle.log_path, "a") do log
             println(log, job_start_banner(handle.job, handle.plan))
-            proc = run(pipeline(setenv(`sandbox-exec -f $(sb_path) $(cmd)`, seatbelt_env);
+            sandbox_cmd = Cmd(`sandbox-exec -f $(sb_path) $(cmd)`; dir=build_path)
+            proc = run(pipeline(setenv(sandbox_cmd, seatbelt_env);
                 stdout=log,
                 stderr=log,
             ); wait=false)

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -279,6 +279,7 @@ function admission_groups_locked(scheduler::Scheduler)
     groups = AdmissionGroup[]
     for brg in scheduler.brgs
         haskey(scheduler.sources, brg.name) || continue
+        group_backend_available(scheduler, brg) || continue
         pool = scheduler.lease_pools[brg.name]
         push!(groups, AdmissionGroup(
             brg.name,
@@ -308,12 +309,14 @@ function pool_status_locked(scheduler::Scheduler)
     groups = Dict{String,Any}()
     for brg in scheduler.brgs
         pool = scheduler.lease_pools[brg.name]
+        available = group_backend_available(scheduler, brg)
         groups[brg.name] = Dict{String,Any}(
             "running" => running(pool),
             "max_jobs" => brg.max_jobs,
             "job_cpus" => brg.job_cpus,
             "priority" => brg.priority,
-            "blocked" => get(plan.blocked, brg.name, false),
+            "backend_available" => available,
+            "blocked" => !available || get(plan.blocked, brg.name, false),
         )
     end
     return Dict{String,Any}(
@@ -433,6 +436,11 @@ function deregister_scheduler_sources!(scheduler::Scheduler)
     return nothing
 end
 
+function group_backend_available(scheduler::Scheduler, brg::BuildkiteRunnerGroup)
+    backend = scheduler.backends[brg.backend]
+    return backend_available(backend, brg)
+end
+
 function job_quarantined_locked!(scheduler::Scheduler, job_id::AbstractString, now::Float64)
     until = get(scheduler.quarantined_jobs, string(job_id), 0.0)
     if until <= now
@@ -471,6 +479,7 @@ function group_can_dispatch(scheduler::Scheduler, group::AbstractString)
         pool = get(scheduler.lease_pools, string(group), nothing)
         pool === nothing && return false
         brg = pool.brg
+        group_backend_available(scheduler, brg) || return false
         return running(pool) < brg.max_jobs &&
             (brg.job_cpus == 0 || free_cpus(scheduler.cpu_pool) >= brg.job_cpus)
     finally

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,6 +56,8 @@ setup_config!(backend::PlatformBackend, brgs::Vector{BuildkiteRunnerGroup}) =
 
 setup_backend!(::PlatformBackend, slots) = nothing
 
+backend_available(::PlatformBackend, brg::BuildkiteRunnerGroup) = true
+
 run_job(handle, deadline::Union{Nothing,Float64}=nothing) =
     error("backend handle does not implement run_job")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ import SandboxedBuildkiteAgent:
     KVMHandle,
     LeasePool,
     LinuxSandboxBackend,
+    MacSeatbeltBackend,
     PlatformBackend,
     Scheduler,
     SchedulerConfig,
@@ -91,6 +92,7 @@ import SandboxedBuildkiteAgent:
     scheduler_status_path,
     read_scheduler_status_snapshot,
     scheduler_systemd_service_installed,
+    seatbelt_setup,
     systemd_status_from_properties,
     scheduled_job_from_json,
     setup_backend!,
@@ -1651,4 +1653,86 @@ end
     @test stopped["detail"] == "last exit code=1"
     clean = launchctl_status_from_output("\tstate = not running\n\tlast exit code = 0\n")
     @test !clean["running"] && clean["detail"] == ""
+end
+
+@testset "macOS seatbelt concurrent slots" begin
+    if Sys.isapple() && Sys.which("sandbox-exec") !== nothing
+        mktempdir() do root
+            secrets = joinpath(root, "secrets")
+            mkpath(secrets)
+            token_path = joinpath(secrets, "buildkite-agent-token")
+            write(token_path, "secret-token\n")
+
+            brg = BuildkiteRunnerGroup("default", Dict{String,Any}(
+                "queues" => "test",
+                "job_cpus" => 6,
+                "max_jobs" => 2,
+                "priority" => 10,
+                "tempdir" => joinpath(root, "tmp-root"),
+                "cachedir" => joinpath(root, "cache-root"),
+                "secrets_dir" => secrets,
+                "tags" => Dict{String,String}("os" => "macos", "arch" => "x86_64"),
+            ); host=:macos, total_cpus=12)
+            backend = MacSeatbeltBackend(joinpath(root, "logs"))
+            probe_job = Job("job", "pipeline", ["queue=test", "os=macos", "arch=x86_64"])
+
+            function run_probe(slot_index)
+                slot = Slot(brg, slot_index)
+                plan = cache_plan(slot, probe_job, :trusted)
+                handle = prepare(backend, slot, probe_job, plan, Allocation(6, ""))
+                observed = Dict{String,String}()
+                seatbelt_setup(brg;
+                    backend,
+                    agent_name=handle.agent_name,
+                    cache_path=handle.plan.cache_pool,
+                    temp_path=handle.temp_path,
+                    alloc=handle.alloc,
+                    agent_token_path=token_path,
+                ) do sb_path, seatbelt_env, build_path
+                    script = raw"""
+set -eu
+printf '%s\n' "$HOME" > "$TMPDIR/home.txt"
+printf '%s\n' "$TMPDIR" > "$HOME/tmpdir.txt"
+printf '%s\n' "$JULIA_CPU_THREADS" > "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR/build/threads.txt"
+printf '%s\n' "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR" > "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR/build/cache.txt"
+pwd -P > "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR/build/pwd.txt"
+mkdir -p "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR/depots/pipeline"
+printf '%s\n' "$HOME" > "$BUILDKITE_PLUGIN_JULIA_CACHE_DIR/depots/pipeline/home.txt"
+sleep 1
+"""
+                    run(setenv(Cmd(`sandbox-exec -f $sb_path /bin/sh -c $script`; dir=build_path), seatbelt_env))
+                    observed["slot"] = slot.name
+                    observed["cache"] = handle.plan.cache_pool
+                    observed["temp"] = handle.temp_path
+                    observed["build_path"] = realpath(build_path)
+                    observed["home"] = strip(read(joinpath(handle.temp_path, "tmp", "home.txt"), String))
+                    observed["tmpdir"] = strip(read(joinpath(handle.temp_path, "home", "tmpdir.txt"), String))
+                    observed["threads"] = strip(read(joinpath(handle.plan.cache_pool, "build", "threads.txt"), String))
+                    observed["cache_env"] = strip(read(joinpath(handle.plan.cache_pool, "build", "cache.txt"), String))
+                    observed["pwd"] = strip(read(joinpath(handle.plan.cache_pool, "build", "pwd.txt"), String))
+                    observed["depot_home"] = strip(read(joinpath(handle.plan.cache_pool, "depots", "pipeline", "home.txt"), String))
+                end
+                return observed
+            end
+
+            results = Vector{Dict{String,String}}(undef, 2)
+            @sync for slot_index in 1:2
+                @async results[slot_index] = run_probe(slot_index)
+            end
+
+            @test length(unique(result["cache"] for result in results)) == 2
+            @test length(unique(result["temp"] for result in results)) == 2
+            @test length(unique(result["home"] for result in results)) == 2
+            @test length(unique(result["tmpdir"] for result in results)) == 2
+            @test length(unique(result["pwd"] for result in results)) == 2
+            for result in results
+                @test result["threads"] == "6"
+                @test result["cache_env"] == result["cache"]
+                @test result["pwd"] == result["build_path"]
+                @test result["depot_home"] == result["home"]
+            end
+        end
+    else
+        @test_skip "sandbox-exec unavailable"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -921,6 +921,10 @@ function prepare(::FailingPrepareBackend, slot::Slot, job::Job, plan::CachePlan,
     error("prepare failed")
 end
 
+struct UnavailableBackend <: PlatformBackend end
+
+SandboxedBuildkiteAgent.backend_available(::UnavailableBackend, brg::BuildkiteRunnerGroup) = false
+
 @testset "scheduler backend registry" begin
     linux = runner_group(;
         name="linux",
@@ -967,6 +971,27 @@ end
     @test run_once!(deadline_scheduler) == 1
     @test length(deadline_backend.deadlines) == 1
     @test 55.0 <= only(deadline_backend.deadlines) - before <= 65.0
+end
+
+@testset "scheduler blocks unavailable backends before reservation" begin
+    brg = runner_group(;
+        cachedir_root=mktempdir(),
+        backend=BACKEND_LINUX_SANDBOX,
+        host=:linux,
+    )
+    source = StaticJobSource([job(; id="blocked-job")])
+    scheduler = test_scheduler(test_scheduler_config(), [brg], source,
+        Dict(BACKEND_LINUX_SANDBOX => UnavailableBackend()))
+
+    @test poll_jobs!(scheduler, brg.name) == 1
+    @test !run_available_assignment!(scheduler)
+    @test isempty(source.reserved)
+    @test isempty(source.finished)
+
+    status = SandboxedBuildkiteAgent.scheduler_status_snapshot(scheduler)
+    group_status = status["pool"]["groups"][brg.name]
+    @test group_status["blocked"]
+    @test !group_status["backend_available"]
 end
 
 @testset "scheduler finishes failed reserved jobs" begin


### PR DESCRIPTION
We have a severe macOS x86 backlog, so I'm going to try splitting up the workers, which should help with the long tail of the test suite. This hasn't been done before, lacking something like cpuset on macOS, but for our pipelines I think we respect JULIA_NUM_CORES everywhere so let's try doing without.