### PR TITLE
Cache Linux sandbox persistence root probes

### DIFF
--- a/src/backends/linux_sandbox.jl
+++ b/src/backends/linux_sandbox.jl
@@ -347,23 +347,49 @@ function host_paths_to_cleanup(::LinuxSandboxBackend, brg, config, agent_name)
     ]
 end
 
-function agent_persist_dir(brg, agent_name)
+const linux_persist_root_lock = ReentrantLock()
+const linux_persist_root_cache = Dict{Tuple{String,Tuple{Vararg{String}}},Tuple{String,Bool}}()
+
+function linux_persistence_hints(brg)
     persistence_hints = String[]
     if persistence_dir(brg) !== nothing
         push!(persistence_hints, persistence_dir(brg))
     end
     push!(persistence_hints, cachedir(brg))
-    rootfs_dir = @artifact_str("buildkite-agent-rootfs", brg.platform)
+    return persistence_hints
+end
 
-    # Once we've found a good persistence root, go into an agent-specific location.
-    persist_root = Sandbox.find_persist_dir_root(rootfs_dir, persistence_hints)[1]
-    if persist_root === nothing
-        error("""
-            No usable persistence directory: none of the candidate paths are on a
-            filesystem that can host an overlayfs upperdir.
-            Tried (in order): $(join(persistence_hints, ", ")).""")
+function linux_persist_root_info(rootfs_dir::String, persistence_hints::Vector{String};
+                                 finder=Sandbox.find_persist_dir_root)
+    key = (rootfs_dir, Tuple(persistence_hints))
+    return lock(linux_persist_root_lock) do
+        get!(linux_persist_root_cache, key) do
+            persist_root, userxattr = finder(rootfs_dir, persistence_hints)
+            if persist_root === nothing
+                error("""
+                    No usable persistence directory: none of the candidate paths are on a
+                    filesystem that can host an overlayfs upperdir.
+                    Tried (in order): $(join(persistence_hints, ", ")).""")
+            end
+            return (persist_root, userxattr)
+        end
     end
-    return joinpath(persist_root, string("persist-", agent_name))
+end
+
+function linux_persist_root_info(brg)
+    persistence_hints = linux_persistence_hints(brg)
+    rootfs_dir = @artifact_str("buildkite-agent-rootfs", brg.platform)
+    return linux_persist_root_info(rootfs_dir, persistence_hints)
+end
+
+function agent_persist_info(brg, agent_name)
+    # Once we've found a good persistence root, go into an agent-specific location.
+    persist_root, userxattr = linux_persist_root_info(brg)
+    return joinpath(persist_root, string("persist-", agent_name)), userxattr
+end
+
+function agent_persist_dir(brg, agent_name)
+    return first(agent_persist_info(brg, agent_name))
 end
 
 function cleanup(backend::LinuxSandboxBackend)
@@ -531,7 +557,7 @@ end
 function sandbox_command(handle::LinuxSandboxHandle)
     brg = handle.slot.brg
     with_executor(UnprivilegedUserNamespacesExecutor) do exe
-        exe.persistence_dir = agent_persist_dir(brg, handle.agent_name)
+        exe.persistence_dir, exe.userxattr = agent_persist_info(brg, handle.agent_name)
         cmd = buildkite_agent_start_command(brg;
             agent_binary="/usr/bin/buildkite-agent",
             hooks_path="/hooks",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,8 @@ import SandboxedBuildkiteAgent:
     guest_agent_ready_timeout,
     guest_agent_stable_for,
     handle_poll_error!,
+    linux_persist_root_cache,
+    linux_persist_root_info,
     cleanup_job_cgroups,
     guest_exec_payload,
     job_cgroup_name,
@@ -1506,6 +1508,29 @@ end
     wrapped = wrap_command_in_cgroup_join_file("/sys/fs/cgroup/test/cgroup.procs", `echo ok`)
     @test wrapped.exec[1] == joinpath(dirname(@__DIR__), "src", "backends", "assets", "host_cgroup_wrapper.sh")
     @test wrapped.exec[2] == "/sys/fs/cgroup/test/cgroup.procs"
+
+    @testset "Linux persistence root probe cache" begin
+        empty!(linux_persist_root_cache)
+        rootfs = mktempdir()
+        hint = mktempdir()
+        calls = Ref(0)
+        finder(rootfs_arg, hints_arg) = begin
+            calls[] += 1
+            @test rootfs_arg == rootfs
+            @test hints_arg == [hint]
+            return (hint, true)
+        end
+
+        @sync for _ in 1:8
+            @async @test linux_persist_root_info(rootfs, [hint]; finder) == (hint, true)
+        end
+        @test calls[] == 1
+
+        empty!(linux_persist_root_cache)
+        @test_throws ErrorException linux_persist_root_info(
+            rootfs, [hint]; finder=(rootfs_arg, hints_arg) -> (nothing, false))
+        empty!(linux_persist_root_cache)
+    end
 
     backend = LinuxSandboxBackend(mktempdir())
     backend.root = "/not/a/real/cgroup"


### PR DESCRIPTION
Works around issue seen in https://buildkite.com/julialang/julia-pr/builds/127/table?jid=019f3a22-41d8-448d-ab36-dd4ab872083a, caused by a racy check and a bug in Sandbox.jl