### PR TITLE
automacci: Replace MDS-based mac CI deployment with plain bash + startosinstall

### DIFF
--- a/macos-seatbelt/automacci/README.md
+++ b/macos-seatbelt/automacci/README.md
@@ -1,38 +1,225 @@
-# Configuration files for automatic deployment of mac CI runners
+# Automatic deployment of mac CI runners
 
-These are configuration files for MDS (https://twocanoes.com/products/mac/mac-deploy-stick/) to quickly setup a new mac in the
-way that CI expects. 
+Scripts to image a mac (Intel or Apple Silicon) into a Julia CI runner:
+erase, install a known macOS, create the `julia` user, enable SSH, and install
+Xcode/Homebrew/juliaup — with one image build up front and near-zero per-machine
+interaction (Intel) or one short Setup Assistant click-through (Apple Silicon).
 
-# Instructions to build a deployment image (.dmg)
+Everything is plain `bash` around Apple's own `startosinstall`. An earlier
+version of this process used MDS (Mac Deploy Stick); see "History" at the
+bottom for why that was dropped.
 
-N.B.: These steps are only required once to rebuild the image. If you're setting up additional macs, using an already-built deployment image is fine.
+## How it works
 
-1. Obtain Xcode from https://developer.apple.com/download/all/?q=xcode
-	1a. Extract xcode.xip and move the resulting .app into the packages/ subfolder of this directory
-2. Downloads MDS (N.B. at time of this writing, only MDS 5 works for macOS >= 13). The default version of
-   MDS is 4. MDS 5 downloads can be found at https://bitbucket.org/twocanoes/macdeploystick/downloads/.
-3. Use MDS' "Download macos" feature to download the appropriate version of macos for CI. The currently recommended macOS version is 13.3.1.
-   Place the downloaded file in this folder.
-4. Import the MDS workflow file found in this folder (setupci.mdsworkflows). You may need to make the following changes (hit "Edit" after importing the workflow0:
-   4a. Adjust the paths for (i) macos Installer (ii) packages (iii) resources to match this folder or its subdirectories.
-   	   (MDS uses absolute paths in its settings).
-   4b. Set a password for the `julia` user. This password is not used in CI, but will be used for SSH.
-   4c. If your mac is connected via wifi, enter wifi credentials in the workflow options.
-5. Hit "Save to disk image" and choose an easy to remember name. Shorter names are better as you will need to type the name later on each machine.
-   5a. It is recommended to set the "Automatically run workflow with name" option to save manual effort. 
-6. Serve the resulting disk image via http at a location accessible to the new mac. (In this writeup we will assume it's at `http://192.168.1.1`).
+`build-image.sh` produces `juliaci.dmg` containing a full macOS installer app,
+`firstboot.pkg`, and two launch scripts (`run` for Intel, `run-as` for Apple
+Silicon). On the target the disk is erased and macOS installed; on the first
+boot of the new system the package suppresses Setup Assistant, and a
+LaunchDaemon (`firstboot/setup.sh`) configures the machine to match what the
+old MDS workflow + the PR #57 follow-up notes established: `julia` user
+(uid 601, zsh, admin) with auto-login (/etc/kcpassword), computer name
+`<prefix>-<serial>` (default prefix `honeycrisp`, see `--name-prefix`), SSH +
+Screen Sharing on, Wi-Fi off, all sleep/hibernation off, restart-on-power-
+failure on; it then fetches Xcode from your HTTP server and runs the
+`scripts/` in order (Xcode select/license, repo clone, Homebrew, juliaup
+release+lts, tailscale, buildbot authorized_keys), and finishes by sweeping
+`chown -R julia /Users/julia`.
 
-# Instructions for deploying an image
+## Building the image (once per macOS/Xcode combination)
 
-1. Put the mac into recovery mode (Cmd-R on Intel mac, hold the power button on Apple Silicon)
-2. Open the terminal and enter:
+Needs a mac with ~40 GB free. All steps in this directory.
+
+1. Pick a macOS version (coordinate with @staticfloat / whatever the existing
+   queue runs). Note: 2018 Intel minis top out at Sequoia (15); macOS 26
+   dropped Intel minis.
+2. Get the **full** installer app, either
+   `softwareupdate --fetch-full-installer --full-installer-version <ver>`
+   (lands in /Applications) or [mist-cli](https://github.com/ninxsoft/mist-cli).
+3. Get a matching Xcode from https://developer.apple.com/download/all/?q=xcode
+   (cross-reference versions at https://xcodereleases.com). Either keep the
+   `.xip`, or expand it to `Xcode.app` (faster per-machine: the image build
+   tars the app once instead of every machine running `xip --expand`).
+4. Build:
+   ```
+   JULIA_PASSWORD='<ssh password for the julia user>' ./build-image.sh \
+       --installer "/Applications/Install macOS Sequoia.app" \
+       --server http://192.168.1.10 \
+       --xcode /path/to/Xcode.app \
+       --output-dir out
+   ```
+5. Serve `out/` at the `--server` URL. The server **must support HTTP range
+   requests** — `python3 -m http.server` does NOT and `hdiutil` will fail
+   against it. Working options: `caddy file-server --root out --listen :8000
+   --access-log` (use `--access-log`: watching requests for the dmg/pkg/Xcode
+   asset is your deployment progress bar and reveals each machine's IP),
+   `npx http-server out -p 80`, or nginx. To see who's connected without
+   logs: `lsof -nP -i :8000`. Verify range support (expect `206`):
+   ```
+   curl -r 0-99 -o /dev/null -s -w '%{http_code}\n' http://192.168.1.10/juliaci.dmg
+   ```
+   The server is needed during deployment *and* during each machine's first
+   boot (that's when Xcode is fetched).
+
+## Deploying a machine
+
+### Intel
+
+1. Boot into Recovery: hold **Cmd-R** (or **Option-Cmd-R** for internet
+   recovery — prefer that on machines whose local recovery is much older than
+   the macOS you're installing).
+2. If on Wi-Fi, join the network from the recovery menu bar.
+3. Utilities → Terminal:
+   ```
+   hdiutil mount http://192.168.1.10/juliaci.dmg
+   /Volumes/JULIACI/run
+   ```
+   (`run -y` skips the confirmation; `run [-y] <volname>` if the target volume
+   isn't named "Macintosh HD" — check Disk Utility, and erase the disk as APFS
+   "Macintosh HD" first if it's blank or hosed.)
+4. Walk away. The machine reboots into the installer (streaming the installer
+   over HTTP — Ethernet strongly recommended), then boots to the login window
+   and runs first-boot setup. Progress: `tail -f /var/log/juliaci-firstboot.log`
+   over SSH once the machine answers.
+
+### Apple Silicon
+
+There is no unattended erase from recovery without MDM — erase+install needs a
+volume-owner's credentials, and only Automated Device Enrollment can skip
+Setup Assistant on a virgin machine. So one short manual hop:
+
+1. Boot the machine as shipped, click through Setup Assistant minimally:
+   skip everything skippable, create a throwaway admin user `setup`.
+2. Terminal:
+   ```
+   hdiutil mount http://192.168.1.10/juliaci.dmg
+   sudo /Volumes/JULIACI/run-as
+   ```
+   It prompts for the `setup` user's credentials, then erases and reinstalls.
+3. The machine must stay networked on first boot (Apple activation). After
+   that, identical to Intel: julia user, SSH, no Setup Assistant.
+
+If an Apple Silicon machine is in an unknown/locked state, DFU-restore it
+first from a host mac with Apple Configurator (`cfgutil restore`), then start
+from step 1.
+
+### Finding a machine on the network
+
+No need to hunt for the IP: setup.sh sets the hostname (`<prefix>-<serial>`,
+serial is on the bottom label) and enables SSH *early* in first boot, so
+`ssh julia@<prefix>-<serial>.local` works minutes after first boot — even
+while the console still shows Setup Assistant or the login window. To
+discover machines without reading labels: `dns-sd -B _ssh._tcp local.`
+Fallback if mDNS is blocked: `arp -a` on the machine serving the image after
+the mini fetches Xcode.
+
+### Afterwards (both)
+
+Verify over SSH (`ssh julia@<ip>`): `xcodebuild -version`, `brew --version`,
+`juliaup status`, `ls ~/src/sandboxed-buildkite-agent`.
+
+Then enroll the machine into the Julia tailnet (headscale). The image installs
+tailscale (`scripts/04-install-tailscale.sh`) but enrollment needs per-machine
+credentials, so it's driven from your machine over SSH:
+
 ```
-hdiutil mount http://192.168.1.1/img.dmg
-/Volumes/mdsresources/run
+./enroll-tailscale.sh <machine-ip>                  # interactive: prints a
+                                                    # URL for the headscale admin
+TS_AUTHKEY=<key> ./enroll-tailscale.sh <machine-ip> # with a preauth key
 ```
-3. Select the workflow (or wait for it to run if selected above)
-4. (On Apple Silicon only). The mac may need to be erased. Follow onscreen instructions. The mac will have to be connected to internet for activation.
-5. Wait.
-6. (On Apple Silicon only). Manually accept the license agreement and select the target disk.
-7. Wait.
-8. The installation should be complete. Please provide SSH login information (IP and password) to @staticfloat for configuration in the buildkite queues.
+
+Either way this runs `tailscale up --login-server https://headscale.julialang.org
+--advertise-tags "tag:julialang-ci"` on the machine (the flags the headscale
+admin expects). The tailnet hostname defaults to the computer name,
+`<prefix>-<serial>`, so no explicit --hostname is needed. The script installs
+tailscale first if the machine was imaged before that script existed.
+
+Finally, send the IP (tailnet name) and julia password to @staticfloat to add
+the machine to the Buildkite queues. That last step (documented in the
+top-level README) amounts to: a `config.toml` from
+`platforms/macos-seatbelt/config.toml.example` with the queue's runner
+groups, the Buildkite agent token into `agent/secrets/buildkite-agent-token`
+(`chmod o-rwx`), then `bin/bk enable && bin/bk start` in
+`~julia/src/sandboxed-buildkite-agent` — the token and queue conventions are
+the org-admin inputs the deployer can't self-serve.
+
+## Troubleshooting / gotchas (hard-won, please append)
+
+- **`hdiutil mount http://...` fails or hangs**: your HTTP server probably
+  doesn't do range requests (see above).
+- **Machine sits at the login window and nothing happens**: the firstboot
+  LaunchDaemon didn't get loaded on that boot — reboot once; it runs on the
+  next boot (it self-removes when done). If still nothing, check
+  `/var/log/juliaci-firstboot.log` and `/var/log/install.log`.
+- **`startosinstall` in recovery rejects flags or crashes**: the recoveryOS is
+  much older than the installer. Reboot with Option-Cmd-R (internet recovery)
+  to get the newest recovery environment.
+- **`--eraseinstall cannot be used in conjunction with --volume`**: correct —
+  in recoveryOS you erase first, then install. `run` does exactly that
+  (`diskutil eraseDisk APFS "Macintosh HD" GPT diskN` + `startosinstall
+  --volume`); `--eraseinstall` is only valid from a booted OS, which is why
+  `run-as` (Apple Silicon path) uses it.
+- **Machine boots into Setup Assistant instead of the login window**: the
+  firstboot package failed or never ran — `.AppleSetupDone` never got
+  touched. Check for `/var/log/juliaci-firstboot.log` (absent → pkg never
+  ran) and grep `/var/log/install.log` for `org.julialang.ci.firstboot`.
+  Field cases, both fixed in the current scripts: (a) PackageKit said
+  `The file "postinstall" doesn't exist` with `NSFilePosixPermissions = 420`
+  — script in the pkg but not executable, from a checkout with lost exec
+  bits; build-image.sh now forces 755 at build time. (b) The pkg was applied
+  only from recovery onto the erased volume — the OS install creates a fresh
+  Data volume and discards pre-placed payload, so deliver via
+  `--installpackage` (recovery-time `installer` is validation only; both are
+  what `run` now does). Rescue without reimaging: click through Setup
+  Assistant with a throwaway admin — account name AND full name must not
+  contain "julia" in any case (macOS aliases full names to logins, so a
+  full name like "Julia" hijacks every julia-targeting command; use
+  `setup`/`setup`) — then
+  `curl -O http://<server>/firstboot.pkg`,
+  `sudo installer -pkg firstboot.pkg -target /`, reboot (setup reboots
+  itself again when done), and later `sudo sysadminctl -deleteUser
+  <throwaway>` from the julia account.
+- **Rolling out a pkg fix without rebuilding the dmg**: build with
+  `--pkg-only`, serve `out/firstboot.pkg`, and launch recovery deploys as
+  `SERVER=http://<host>:<port> bash run` — `run` then prefers the served pkg
+  over the one baked into the dmg.
+- **firstboot.pkg via `--installpackage` (Apple Silicon run-as path)**: must
+  be a distribution ("product archive") package — `build-image.sh` wraps
+  with `productbuild`. If packages mysteriously don't apply there, try
+  signing: `PKG_SIGN_ID="Developer ID Installer: ..." ./build-image.sh ...`.
+- **Cmd-R doesn't enter recovery on a used T2 machine**: firmware password
+  set by the previous owner; you need it (or an Apple Store) to clear it.
+- **julia user has no secure token / volume ownership** (script-created
+  users don't get one): known; CI doesn't need it. On fully-unattended
+  machines nobody holds a token — for OS upgrades, redeploy the image. On
+  machines where a human clicked through Setup Assistant (rescues, Apple
+  Silicon), the throwaway SA user holds the only token and macOS refuses to
+  delete "the last secure token user" — transfer it first, then delete:
+  `sysadminctl -secureTokenOn julia -password <julia-pw> -adminUser
+  <throwaway> -adminPassword <pw>`, then `sysadminctl -deleteUser
+  <throwaway>`. Bonus: that julia is then a volume owner.
+- **Xcode license/first-launch prompts on first build**: should be handled by
+  `scripts/00-select-xcode.sh` (`-license accept`, `-runFirstLaunch`); re-run
+  it if Xcode was installed manually after deployment.
+- Historical script bugs fixed in the bash rewrite, kept here so they aren't
+  reintroduced: Homebrew shellenv hardcoded the Apple Silicon prefix
+  (`/opt/homebrew`) which is wrong on Intel (`/usr/local`);
+  `NONINTERACTIVE=1 sudo -i ...` never reached the Homebrew installer because
+  `sudo -i` scrubs the environment; `sudo -i -u julia curl ... | sh` ran the
+  juliaup installer as root (the pipe's right-hand side is not under sudo);
+  the Homebrew installer switches xcode-select to the Command Line Tools it
+  installs, undoing 00-select-xcode.sh (02 now switches back); `brew` cannot
+  run as root from a LaunchDaemon ("Error: $HOME must be set") so root-side
+  scripts must use hardcoded brew-adjacent paths, never `brew --prefix`.
+
+## History
+
+This process originally (PR #57, 2023) used MDS
+(https://twocanoes.com/products/mac/mds/) with the workflow file
+`setupci.mdsworkflows` kept in this directory. MDS became a paid subscription
+(~2024); it can still be built from its open source at
+https://bitbucket.org/twocanoes/macdeploystick (needs
+`carthage bootstrap --use-xcframeworks --platform macOS` and "Sign to Run
+Locally"), but since its Intel value was a GUI around `startosinstall` and its
+Apple Silicon flow was no more unattended than the above, it was replaced with
+these scripts. At real fleet scale, the sanctioned fully-unattended path is
+Apple Business Manager + an MDM with Automated Device Enrollment.

--- a/macos-seatbelt/automacci/build-image.sh
+++ b/macos-seatbelt/automacci/build-image.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Build the Julia CI mac deployment image.
+#
+# Replaces the earlier MDS-based flow (MDS went paid in ~2024; see README).
+# Must run on macOS — uses pkgbuild/productbuild/hdiutil.
+#
+# Produces, in --output-dir:
+#   juliaci.dmg      serve over HTTP; contains the macOS installer app,
+#                    firstboot.pkg, and the run / run-as launch scripts
+#   <Xcode asset>    (optional) Xcode archive fetched by machines at first boot
+#
+# The whole output dir must then be served at the URL given via --server, by a
+# server that supports HTTP range requests (hdiutil needs them; python3 -m
+# http.server does NOT — use caddy, nginx, or `npx http-server`).
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+usage: JULIA_PASSWORD=... ./build-image.sh \
+           --installer "/path/Install macOS <Name>.app" \
+           --server http://<host>[:port] \
+           [--xcode /path/Xcode.app | /path/Xcode.xip] \
+           [--output-dir out]
+
+  JULIA_PASSWORD  (env) password for the 'julia' user; used for SSH afterwards
+  --installer     full macOS installer app. Obtain with
+                  `softwareupdate --fetch-full-installer --full-installer-version <ver>`
+                  or mist-cli (https://github.com/ninxsoft/mist-cli)
+  --server        base URL where --output-dir will be served; machines fetch
+                  the Xcode asset from here at first boot
+  --xcode         Xcode.app (packed into a .tar) or an Xcode.xip (copied as-is;
+                  expanded on the target, which is slower per-machine)
+  --output-dir    default: ./out
+EOF
+    exit 1
+}
+
+INSTALLER="" SERVER="" XCODE="" OUTDIR=out PKG_ONLY="" XCODE_ASSET_OVERRIDE="" NAME_PREFIX=honeycrisp
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --installer)   INSTALLER="$2"; shift 2;;
+        --server)      SERVER="${2%/}"; shift 2;;
+        --xcode)       XCODE="$2"; shift 2;;
+        --output-dir)  OUTDIR="$2"; shift 2;;
+        # Rebuild only firstboot.pkg into --output-dir (seconds, not the
+        # ~30min dmg recompress). --xcode-asset names an already-served
+        # Xcode archive to reference in the pkg config without repacking.
+        --pkg-only)    PKG_ONLY=1; shift;;
+        --xcode-asset) XCODE_ASSET_OVERRIDE="$2"; shift 2;;
+        # machines name themselves <prefix>-<serial>; default matches the
+        # MDS-era honeycrisp-{{serial_number}} convention
+        --name-prefix) NAME_PREFIX="$2"; shift 2;;
+        *) usage;;
+    esac
+done
+
+[ -n "$SERVER" ] || usage
+if [ -z "$PKG_ONLY" ]; then
+    [ -n "$INSTALLER" ] || usage
+    [ -d "$INSTALLER" ] || { echo "error: installer app not found: $INSTALLER"; exit 1; }
+    [ -x "$INSTALLER/Contents/Resources/startosinstall" ] || {
+        echo "error: $INSTALLER has no Contents/Resources/startosinstall —"
+        echo "       it must be a *full* installer app, not a stub"; exit 1; }
+fi
+[ -n "${JULIA_PASSWORD:-}" ] || { echo "error: set JULIA_PASSWORD in the environment"; exit 1; }
+
+SRCDIR="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d /tmp/juliaci-image.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$OUTDIR"
+
+# ---- Xcode asset ------------------------------------------------------------
+XCODE_ASSET="$XCODE_ASSET_OVERRIDE"
+if [ -n "$XCODE" ] && [ -z "$XCODE_ASSET_OVERRIDE" ]; then
+    case "$XCODE" in
+        *.xip)
+            XCODE_ASSET="$(basename "$XCODE")"
+            echo "==> Copying $XCODE_ASSET"
+            cp -c "$XCODE" "$OUTDIR/" 2>/dev/null || cp "$XCODE" "$OUTDIR/";;
+        *.app)
+            XCODE_ASSET="Xcode.app.tar"
+            echo "==> Packing $XCODE into $XCODE_ASSET (uncompressed; it's for the LAN)"
+            tar -cf "$OUTDIR/$XCODE_ASSET" -C "$(dirname "$XCODE")" "$(basename "$XCODE")";;
+        *) echo "error: --xcode must be an .app or a .xip"; exit 1;;
+    esac
+fi
+
+# ---- firstboot.pkg ----------------------------------------------------------
+echo "==> Building firstboot.pkg"
+PAYLOAD="$WORK/payload"
+mkdir -p "$PAYLOAD/private/var/juliaci/scripts" "$PAYLOAD/Library/LaunchDaemons"
+cp "$SRCDIR/firstboot/setup.sh"                          "$PAYLOAD/private/var/juliaci/"
+cp "$SRCDIR/firstboot/org.julialang.ci.firstboot.plist"  "$PAYLOAD/Library/LaunchDaemons/"
+cp "$SRCDIR"/scripts/*.sh                                "$PAYLOAD/private/var/juliaci/scripts/"
+printf '%s' "$JULIA_PASSWORD" > "$PAYLOAD/private/var/juliaci/password"
+cat > "$PAYLOAD/private/var/juliaci/config" <<EOF
+SERVER_URL="$SERVER"
+XCODE_ASSET="$XCODE_ASSET"
+COMPUTER_NAME_PREFIX="$NAME_PREFIX"
+EOF
+chmod 755 "$PAYLOAD/private/var/juliaci/setup.sh" "$PAYLOAD"/private/var/juliaci/scripts/*.sh
+chmod 600 "$PAYLOAD/private/var/juliaci/password"
+chmod 644 "$PAYLOAD/Library/LaunchDaemons/org.julialang.ci.firstboot.plist"
+
+# Copy pkg scripts and force the exec bit — a checkout with wrong modes must
+# not produce a pkg whose postinstall PackageKit can't run (it reports that
+# as "The file "postinstall" doesn't exist", and the machine lands in Setup
+# Assistant because .AppleSetupDone was never touched).
+PKGSCRIPTS="$WORK/pkgscripts"
+mkdir -p "$PKGSCRIPTS"
+cp "$SRCDIR"/firstboot/pkgscripts/* "$PKGSCRIPTS/"
+chmod 755 "$PKGSCRIPTS"/*
+
+pkgbuild --root "$PAYLOAD" \
+         --scripts "$PKGSCRIPTS" \
+         --identifier org.julialang.ci.firstboot \
+         --version 1.0 \
+         --install-location / \
+         --ownership recommended \
+         "$WORK/firstboot-component.pkg"
+# startosinstall --installpackage requires a distribution ("product archive")
+# package, so wrap the component pkg. NOTE: the Intel 'run' path applies the
+# pkg itself from recovery and doesn't care about signing, but the Apple
+# Silicon 'run-as' path goes through startosinstall --installpackage, which
+# silently drops packages it doesn't like — sign with a Developer ID
+# Installer identity if you have one:
+#   PKG_SIGN_ID="Developer ID Installer: <name> (<team>)"
+if [ -n "${PKG_SIGN_ID:-}" ]; then
+    productbuild --sign "$PKG_SIGN_ID" \
+        --package "$WORK/firstboot-component.pkg" "$WORK/firstboot.pkg"
+else
+    productbuild --package "$WORK/firstboot-component.pkg" "$WORK/firstboot.pkg"
+fi
+
+if [ -n "$PKG_ONLY" ]; then
+    cp "$WORK/firstboot.pkg" "$OUTDIR/firstboot.pkg"
+    cat <<EOF
+
+Done: $OUTDIR/firstboot.pkg (dmg untouched). Machines can use it via:
+  recovery:  SERVER=$SERVER bash run      (run fetches the fresh pkg)
+  booted OS: curl -O $SERVER/firstboot.pkg && sudo installer -pkg firstboot.pkg -target /
+EOF
+    exit 0
+fi
+
+# ---- disk image -------------------------------------------------------------
+echo "==> Building juliaci.dmg (this copies the ~15GB installer; be patient)"
+STAGE="$WORK/stage"
+mkdir -p "$STAGE"
+cp -R "$INSTALLER" "$STAGE/"
+cp "$WORK/firstboot.pkg" "$STAGE/"
+cp "$SRCDIR/deploy/run" "$SRCDIR/deploy/run-as" "$STAGE/"
+chmod 755 "$STAGE/run" "$STAGE/run-as"
+# HFS+ so that even old recovery environments can mount it
+hdiutil create -volname JULIACI -fs HFS+ -format UDZO -srcfolder "$STAGE" -ov \
+    "$OUTDIR/juliaci.dmg"
+
+cat <<EOF
+
+Done. Now serve '$OUTDIR' at $SERVER with a range-request-capable server, e.g.:
+    npx http-server '$OUTDIR' -p 80
+Verify ranges work (expect 206):
+    curl -r 0-99 -o /dev/null -s -w '%{http_code}\n' $SERVER/juliaci.dmg
+Then follow README.md "Deploying a machine".
+EOF

--- a/macos-seatbelt/automacci/deploy/run
+++ b/macos-seatbelt/automacci/deploy/run
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Deploy Julia CI onto an INTEL mac, from Recovery.
+#
+#   1. Boot holding Cmd-R (prefer Option-Cmd-R: newest recoveryOS, whose
+#      environment is least likely to reject a newer installer)
+#   2. Utilities > Terminal:
+#        hdiutil mount http://<server>/juliaci.dmg
+#        /Volumes/JULIACI/run
+#
+# ERASES the internal disk, then installs macOS + firstboot.pkg onto it.
+# (In recoveryOS `startosinstall --eraseinstall` cannot be combined with
+# --volume, so we erase with diskutil first and plain-install.)
+#
+# Usage: run [-y] [diskN]     (default disk: first internal physical disk)
+set -euo pipefail
+
+# Fixed volume name so this script also works when fetched via curl rather
+# than executed off the mounted image.
+VOL=/Volumes/JULIACI
+[ -d "$VOL" ] || { echo "error: $VOL not mounted — hdiutil mount the dmg first"; exit 1; }
+
+ASSUME_YES=""
+[ "${1:-}" = "-y" ] && { ASSUME_YES=1; shift; }
+
+DISK="${1:-$(diskutil list internal physical | sed -n 's|^/dev/\(disk[0-9]*\).*|\1|p' | head -1)}"
+[ -n "$DISK" ] || { echo "error: no internal disk found (diskutil list internal physical)"; exit 1; }
+
+INSTALLERS=("$VOL"/Install\ macOS*.app)
+INSTALLER="${INSTALLERS[0]}"
+[ -d "$INSTALLER" ] || { echo "error: no installer app on $VOL"; exit 1; }
+
+echo "About to ERASE /dev/$DISK:"
+diskutil list "$DISK"
+# ${x##*/} not basename: recoveryOS shells can lack coreutils on PATH
+echo "and install ${INSTALLER##*/} + firstboot.pkg"
+if [ -z "$ASSUME_YES" ]; then
+    printf "Type yes to continue: "
+    read -r ANSWER
+    [ "$ANSWER" = "yes" ] || exit 1
+fi
+
+diskutil eraseDisk APFS "Macintosh HD" GPT "$DISK"
+
+# If SERVER is set, prefer a freshly served pkg over the one baked into the
+# dmg — lets pkg fixes roll out without a ~30min image rebuild:
+#     SERVER=http://<host>:<port> bash run
+PKG="$VOL/firstboot.pkg"
+if [ -n "${SERVER:-}" ]; then
+    curl -f -o /tmp/firstboot.pkg "${SERVER%/}/firstboot.pkg" && PKG=/tmp/firstboot.pkg
+fi
+
+# Pre-flight validation ONLY: run the pkg against the erased volume so a
+# broken package (bad archive, failing script) aborts loudly here, in front
+# of the operator. Its *effects do not persist* — the OS install creates a
+# fresh Data volume, discarding anything pre-placed (observed in the field:
+# machine came up with no trace of the payload). Delivery happens via
+# --installpackage below, which stages the pkg through the install and runs
+# it at first boot, before loginwindow. Unsigned product archives are fine
+# there (also proven in the field — the one observed failure was a
+# non-executable script, not signing).
+installer -pkg "$PKG" -target "/Volumes/Macintosh HD"
+
+"$INSTALLER/Contents/Resources/startosinstall" \
+    --agreetolicense --nointeraction --forcequitapps \
+    --volume "/Volumes/Macintosh HD" \
+    --installpackage "$PKG"

--- a/macos-seatbelt/automacci/deploy/run-as
+++ b/macos-seatbelt/automacci/deploy/run-as
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Deploy Julia CI onto an APPLE SILICON mac, from a *booted* macOS.
+#
+# Apple Silicon has no unattended recovery path without MDM: erase+install
+# needs the credentials of a volume-owner admin. So: boot the machine, click
+# through Setup Assistant just far enough to create a throwaway admin user
+# (suggested name: setup), then in Terminal:
+#     hdiutil mount http://<server>/juliaci.dmg
+#     sudo /Volumes/JULIACI/run-as
+#
+# ERASES the machine. It reboots into the installer; the firstboot.pkg then
+# creates the julia user and Setup Assistant never runs again. The machine
+# must have internet on first boot (activation).
+set -euo pipefail
+
+[ "$(id -u)" = 0 ] || { echo "error: run with sudo"; exit 1; }
+[ "$(uname -m)" = arm64 ] || {
+    echo "error: this is an Intel mac — deploy it from Recovery with 'run'"; exit 1; }
+
+# fixed path, and no dirname/basename: minimal shells can lack coreutils
+VOL=/Volumes/JULIACI
+[ -d "$VOL" ] || { echo "error: $VOL not mounted — hdiutil mount the dmg first"; exit 1; }
+INSTALLERS=("$VOL"/Install\ macOS*.app)
+INSTALLER="${INSTALLERS[0]}"
+[ -d "$INSTALLER" ] || { echo "error: no installer app on $VOL"; exit 1; }
+
+# SUDO_USER is normally the throwaway admin created in Setup Assistant, which
+# is a volume owner.
+DEFAULT_OWNER="${SUDO_USER:-setup}"
+printf "Volume-owner admin username [%s]: " "$DEFAULT_OWNER"
+read -r OWNER
+OWNER="${OWNER:-$DEFAULT_OWNER}"
+printf "Password for %s: " "$OWNER"
+read -rs PASS
+echo
+
+echo "About to ERASE this machine and install ${INSTALLER##*/} + firstboot.pkg."
+printf "Type yes to continue: "
+read -r ANSWER
+[ "$ANSWER" = "yes" ] || exit 1
+
+printf '%s\n' "$PASS" | "$INSTALLER/Contents/Resources/startosinstall" \
+    --agreetolicense --nointeraction --forcequitapps \
+    --eraseinstall --newvolumename "Macintosh HD" \
+    --installpackage "$VOL/firstboot.pkg" \
+    --user "$OWNER" --stdinpass

--- a/macos-seatbelt/automacci/enroll-tailscale.sh
+++ b/macos-seatbelt/automacci/enroll-tailscale.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Enroll a deployed CI mac into https://headscale.julialang.org.
+# Run from YOUR machine (host side) — enrollment credentials must not be
+# baked into the deployment image.
+#
+# usage: ./enroll-tailscale.sh <machine-ip> [-- extra tailscale-up flags]
+#
+# Auth, either of:
+#   TS_AUTHKEY=<preauth key>  — non-interactive (headscale admin creates one:
+#                               `headscale preauthkeys create --user <u>`)
+#   no TS_AUTHKEY             — interactive: tailscale prints a registration
+#                               URL; send it to the headscale admin
+#
+# Machines advertise tag:julialang-ci (per the headscale admin) and keep the
+# default tailnet hostname = the computer name, i.e. <prefix>-<serial>.
+#
+# Self-healing: installs tailscale + the system daemon if the machine was
+# imaged before 04-install-tailscale.sh (or hit its early bugs).
+set -euo pipefail
+
+[ $# -ge 1 ] || { sed -n '2,17p' "$0"; exit 1; }
+IP="$1"; shift
+[ "${1:-}" = "--" ] && shift
+EXTRA_FLAGS=("$@")
+
+LOGIN_SERVER=https://headscale.julialang.org
+TAGS="tag:julialang-ci"
+
+# Self-heal: install the formula and/or register the system daemon if
+# missing. tailscaled is linked next to brew — do not use `brew --prefix`
+# under sudo, root has no $HOME for brew.
+ssh "julia@$IP" '
+    set -e
+    BREW=$([ "$(uname -m)" = arm64 ] && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew)
+    "$BREW" list tailscale >/dev/null 2>&1 || "$BREW" install tailscale
+    if [ ! -f /Library/LaunchDaemons/com.tailscale.tailscaled.plist ]; then
+        sudo "$(dirname "$BREW")/tailscaled" install-system-daemon
+    fi
+'
+
+if [ -n "${TS_AUTHKEY:-}" ]; then
+    # Ship the key via stdin into a root-only file and use --auth-key file:
+    # so it never appears in argv/ps on either end; removed afterwards.
+    printf '%s' "$TS_AUTHKEY" | ssh "julia@$IP" '
+        set -e
+        BREW=$([ "$(uname -m)" = arm64 ] && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew)
+        TS="$(dirname "$BREW")/tailscale"
+        sudo sh -c "umask 077; cat > /private/var/root/ts.authkey"
+        sudo "$TS" up --login-server '"$LOGIN_SERVER"' \
+            --advertise-tags '"$TAGS"' \
+            --auth-key file:/private/var/root/ts.authkey '"${EXTRA_FLAGS[*]:-}"'
+        sudo rm -f /private/var/root/ts.authkey
+        sudo "$TS" status | head -5
+    '
+else
+    # Interactive: prints a URL to hand to the headscale admin.
+    ssh -t "julia@$IP" '
+        BREW=$([ "$(uname -m)" = arm64 ] && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew)
+        TS="$(dirname "$BREW")/tailscale"
+        sudo "$TS" up --login-server '"$LOGIN_SERVER"' \
+            --advertise-tags '"$TAGS"' '"${EXTRA_FLAGS[*]:-}"'
+        sudo "$TS" status | head -5
+    '
+fi
+echo "Enrolled $IP on $LOGIN_SERVER"

--- a/macos-seatbelt/automacci/firstboot/org.julialang.ci.firstboot.plist
+++ b/macos-seatbelt/automacci/firstboot/org.julialang.ci.firstboot.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.julialang.ci.firstboot</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>/private/var/juliaci/setup.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/var/log/juliaci-firstboot.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/juliaci-firstboot.log</string>
+</dict>
+</plist>

--- a/macos-seatbelt/automacci/firstboot/pkgscripts/postinstall
+++ b/macos-seatbelt/automacci/firstboot/pkgscripts/postinstall
@@ -1,0 +1,27 @@
+#!/bin/bash
+# postinstall for firstboot.pkg. startosinstall applies --installpackage
+# packages during the first boot of the freshly installed system; $3 is the
+# target volume (usually "/" at that point, but handle both).
+set -x
+TARGET="${3:-/}"
+
+# Suppress Setup Assistant — the machine goes straight to the login window.
+mkdir -p "$TARGET/private/var/db"
+touch "$TARGET/private/var/db/.AppleSetupDone"
+
+# The payload delivered the LaunchDaemon and /private/var/juliaci; make sure
+# ownership survives however the payload was applied.
+chown root:wheel "$TARGET/Library/LaunchDaemons/org.julialang.ci.firstboot.plist"
+chmod 644       "$TARGET/Library/LaunchDaemons/org.julialang.ci.firstboot.plist"
+chown -R root:wheel "$TARGET/private/var/juliaci"
+chmod 600 "$TARGET/private/var/juliaci/password"
+
+# When installing onto the live system ("/" — i.e. at first boot via
+# --installpackage, or a manual rescue install), launchd has already scanned
+# /Library/LaunchDaemons and won't notice the plist until the next reboot.
+# Kick it explicitly so setup starts on THIS boot.
+if [ "$TARGET" = "/" ]; then
+    launchctl load /Library/LaunchDaemons/org.julialang.ci.firstboot.plist || true
+fi
+
+exit 0

--- a/macos-seatbelt/automacci/firstboot/setup.sh
+++ b/macos-seatbelt/automacci/firstboot/setup.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Julia CI first-boot setup. Delivered by firstboot.pkg and run as root by the
+# org.julialang.ci.firstboot LaunchDaemon on the first boot after deployment.
+# Logs to /var/log/juliaci-firstboot.log (tail it to watch progress).
+# Idempotent: to re-run after fixing something, reinstall the pkg (restores
+# payload + LaunchDaemon), `rm /private/var/juliaci/.done`, reboot.
+BASE=/private/var/juliaci
+exec >>/var/log/juliaci-firstboot.log 2>&1
+set -x
+
+finish() {
+    rm -f /Library/LaunchDaemons/org.julialang.ci.firstboot.plist
+}
+if [ -e "$BASE/.done" ]; then
+    finish
+    exit 0
+fi
+
+# Belt-and-suspenders: the pkg postinstall also does this, but the OS install
+# rebuilds /var/db and can drop a pre-placed copy; without it the machine
+# shows Setup Assistant while this script runs behind it.
+touch /private/var/db/.AppleSetupDone
+
+# config provides SERVER_URL and (optionally) XCODE_ASSET, COMPUTER_NAME_PREFIX
+. "$BASE/config"
+
+# Wait for the network (up to 10 minutes). Probe a file that actually exists
+# on the deploy server (bare "/" 404s on index-less file servers); fall back
+# to apple.com in case the server is only needed for Xcode.
+for _ in $(seq 1 60); do
+    curl -fsI --max-time 5 "$SERVER_URL/firstboot.pkg" >/dev/null 2>&1 && break
+    curl -fsI --max-time 5 https://www.apple.com/ >/dev/null 2>&1 && break
+    sleep 10
+done
+
+# Passwordless sudo for julia (needed by the setup scripts and by Homebrew on
+# Intel, where the installer sudos to create /usr/local directories).
+grep -q '^julia ALL' /etc/sudoers || echo 'julia ALL = NOPASSWD: ALL' >>/etc/sudoers
+
+# Create the julia user (uid 601 and zsh shell match the old MDS workflow).
+# NOTE (Apple Silicon): a user created here, before any Setup Assistant user
+# exists, may not hold a secure token / volume ownership. CI doesn't need
+# one; OS *upgrades* on such machines are easiest done by redeploying.
+# Existence check MUST be the exact record path, not `id julia`: macOS
+# resolves user names against full names case-insensitively, so a human
+# account with full name "Julia ..." makes `id julia` succeed and every
+# julia-targeting command silently operate on the wrong user (observed in
+# the field with a throwaway Setup Assistant account).
+if ! dscl . -read /Users/julia UniqueID >/dev/null 2>&1; then
+    sysadminctl -addUser julia -fullName "Julia Hub" -UID 601 -shell /bin/zsh \
+        -admin -password "$(cat "$BASE/password")"
+fi
+dscl . -read /Users/julia UniqueID >/dev/null 2>&1 || \
+    echo "JULIACI FATAL: julia user creation failed"
+# Guarantee the home dir exists ourselves — createhomedir has been seen not
+# delivering (field: /Users/julia absent, every later script broke or leaked
+# into the invoking user's home via a failing 'sudo -i' login shell).
+if [ ! -d /Users/julia ]; then
+    mkdir -p /Users/julia
+    chown julia:staff /Users/julia
+    createhomedir -c -u julia || true
+    chown -R julia:staff /Users/julia
+fi
+
+# Suppress julia's per-user first-login Setup Assistant (Apple ID, Siri,
+# privacy panes — the MDS workflow's shouldSkipPrivacySetup). Without this,
+# auto-login walks straight into those panes on first boot.
+SA_PLIST=/Users/julia/Library/Preferences/com.apple.SetupAssistant
+mkdir -p /Users/julia/Library/Preferences
+for k in DidSeeCloudSetup DidSeeSiriSetup DidSeePrivacy DidSeeAppearanceSetup \
+         DidSeeAvatarSetup DidSeeScreenTime DidSeeTouchIDSetup \
+         DidSeeAccessibility DidSeeActivationLock DidSeeApplePaySetup \
+         DidSeeTrueTonePrivacy; do
+    defaults write "$SA_PLIST" "$k" -bool true
+done
+defaults write "$SA_PLIST" LastSeenCloudProductVersion "$(sw_vers -productVersion)"
+defaults write "$SA_PLIST" LastSeenBuddyBuildVersion "$(sw_vers -buildVersion)"
+chown -R julia:staff /Users/julia/Library
+
+# Auto-login as julia (CI jobs want a real GUI session; matches the MDS
+# workflow's shouldAutologin). /etc/kcpassword is the password XORed with
+# Apple's fixed 11-byte key, NUL-terminated, padded to a multiple of 12.
+# Trivially reversible by design — acceptable for CI machines, and it's what
+# every deployment tool does. Requires FileVault off (it is, fresh install).
+kcpassword_encode() {
+    local pw="$1"
+    local key=(125 137 82 35 210 188 221 234 163 185 31)
+    local out="" i c n=${#pw}
+    for (( i=0; i<n; i++ )); do
+        c=$(printf '%d' "'${pw:i:1}")
+        out+=$(printf '\\%03o' $(( c ^ key[i % 11] )))
+    done
+    out+=$(printf '\\%03o' $(( key[i % 11] )) ); i=$((i+1))
+    while (( i % 12 != 0 )); do
+        out+=$(printf '\\%03o' $(( key[i % 11] )) ); i=$((i+1))
+    done
+    printf '%b' "$out"
+}
+if [ -f "$BASE/password" ]; then
+    kcpassword_encode "$(cat "$BASE/password")" > /etc/kcpassword
+    chown root:wheel /etc/kcpassword
+    chmod 600 /etc/kcpassword
+    defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string julia
+fi
+rm -f "$BASE/password"
+
+# Computer name: <prefix>-<serial>, matching the MDS workflow's
+# honeycrisp-{{serial_number}} convention.
+SERIAL="$(ioreg -rd1 -c IOPlatformExpertDevice | awk -F'"' '/IOPlatformSerialNumber/{print $4}')"
+if [ -n "$SERIAL" ]; then
+    NAME="${COMPUTER_NAME_PREFIX:-honeycrisp}-${SERIAL}"
+    scutil --set ComputerName "$NAME"
+    scutil --set HostName "$NAME"
+    scutil --set LocalHostName "$NAME"
+fi
+
+# Remote access: SSH and Screen Sharing.
+systemsetup -setremotelogin on || launchctl load -w /System/Library/LaunchDaemons/ssh.plist
+launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist || true
+
+# Never sleep, in any form; restart after power failure. caffeinate alone has
+# been seen losing to power management on macOS 15 (PR #57 discussion), hence
+# the full battery of settings; some keys don't exist on some hardware.
+pmset -a sleep 0 displaysleep 0 disksleep 0 || true
+pmset -a hibernatemode 0 || true
+pmset -a autopoweroff 0 || true
+pmset -a standby 0 || true
+pmset -a lidwake 0 || true
+pmset -a autorestart 1 womp 1 || true
+
+# CI machines are wired; kill Wi-Fi so machines can't wander onto it
+# (PR #57 discussion, staticfloat's note 3).
+WIFIDEV="$(networksetup -listallhardwareports | awk '/Wi-Fi|AirPort/{getline; print $2}')"
+[ -n "$WIFIDEV" ] && networksetup -setairportpower "$WIFIDEV" off || true
+
+# Fetch and unpack Xcode if the image was built with one.
+if [ -n "${XCODE_ASSET:-}" ] && [ ! -d /Applications/Xcode.app ]; then
+    cd /Applications
+    case "$XCODE_ASSET" in
+        *.xip)
+            curl -fO "$SERVER_URL/$XCODE_ASSET"
+            xip --expand "$XCODE_ASSET"   # slow: ~30+ minutes
+            rm -f "$XCODE_ASSET"
+            # xip may expand to a versioned name; normalize
+            [ -d Xcode.app ] || mv Xcode*.app Xcode.app
+            ;;
+        *.tar)          curl -f "$SERVER_URL/$XCODE_ASSET" | tar -x ;;
+        *.tar.gz|*.tgz) curl -f "$SERVER_URL/$XCODE_ASSET" | tar -xz ;;
+    esac
+    cd /
+fi
+
+# Run the setup scripts in order (00-select-xcode, 01-clone, 02-homebrew,
+# 03-juliaup, 04-tailscale, 05-ssh-key). Keep going on failure — a partially
+# set up machine that answers SSH beats one that never comes up; failures are
+# visible in the log.
+FAILED=""
+for s in "$BASE"/scripts/*.sh; do
+    bash "$s" || FAILED="$FAILED $s"
+done
+
+# The setup scripts run installers as root that occasionally leave
+# root-owned droppings in julia's home (PR #57 discussion, staticfloat's
+# note 2); sweep ownership at the end.
+chown -R julia /Users/julia || true
+
+[ -n "$FAILED" ] && echo "JULIACI SETUP FAILURES:$FAILED"
+touch "$BASE/.done"
+finish
+echo "JULIACI SETUP COMPLETE"
+
+# One reboot so loginwindow re-reads autologin/.AppleSetupDone — lands on
+# julia's desktop with no operator touches. No loop risk: .done short-
+# circuits the next run.
+reboot

--- a/macos-seatbelt/automacci/scripts/00-select-xcode.sh
+++ b/macos-seatbelt/automacci/scripts/00-select-xcode.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
+if [ ! -d /Applications/Xcode.app ]; then
+    echo "Xcode.app not installed; skipping (install it and re-run this script)"
+    exit 1
+fi
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer/
 sudo xcodebuild -license accept
+sudo xcodebuild -runFirstLaunch || true

--- a/macos-seatbelt/automacci/scripts/01-clone-buildkite-agent.sh
+++ b/macos-seatbelt/automacci/scripts/01-clone-buildkite-agent.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-sudo -i -u julia mkdir -p /Users/julia/src/
-sudo -i -u julia git clone https://github.com/JuliaCI/sandboxed-buildkite-agent /Users/julia/src/sandboxed-buildkite-agent
+sudo -H -u julia mkdir -p /Users/julia/src/
+[ -d /Users/julia/src/sandboxed-buildkite-agent ] || \
+    sudo -H -u julia git clone https://github.com/JuliaCI/sandboxed-buildkite-agent /Users/julia/src/sandboxed-buildkite-agent

--- a/macos-seatbelt/automacci/scripts/02-install-homebrew.sh
+++ b/macos-seatbelt/automacci/scripts/02-install-homebrew.sh
@@ -1,12 +1,38 @@
 #!/bin/bash
-# Allow passwordless sudo for julia
-bash -c "echo julia ALL = NOPASSWD: ALL >> /etc/sudoers"
+# Allow passwordless sudo for julia (idempotent; the Intel Homebrew installer
+# sudos to create /usr/local directories)
+grep -q '^julia ALL' /etc/sudoers || \
+    bash -c "echo julia ALL = NOPASSWD: ALL >> /etc/sudoers"
 
 # Create .bash_profile for juliaup to modify
-sudo -i -u julia touch /Users/julia/.bash_profile
+sudo -H -u julia touch /Users/julia/.bash_profile
 
-# Setup homebrew
-NONINTERACTIVE=1 sudo -i -u julia /bin/bash -c "curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | /bin/bash"
+# Setup homebrew. NONINTERACTIVE must be passed *through* sudo (a leading
+# NONINTERACTIVE=1 would be scrubbed from the environment). -H (not -i):
+# login shells break when the home dir is missing/broken, -H just sets HOME.
+sudo -H -u julia NONINTERACTIVE=1 /bin/bash -c \
+    "curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash"
 
-# Add homebrew to profile
-(echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/julia/.bash_profile
+# Add homebrew to profile. Prefix differs by architecture: /opt/homebrew on
+# Apple Silicon, /usr/local on Intel.
+if [ "$(uname -m)" = "arm64" ]; then
+    BREW=/opt/homebrew/bin/brew
+else
+    BREW=/usr/local/bin/brew
+fi
+grep -q 'brew shellenv' /Users/julia/.bash_profile || \
+    (echo; echo "eval \"\$(${BREW} shellenv)\"") >> /Users/julia/.bash_profile
+
+# zsh is the login default (and julia's shell), so .zprofile needs it too
+# (PR #57 discussion, maleadt's note 2).
+sudo -H -u julia touch /Users/julia/.zprofile
+grep -q 'brew shellenv' /Users/julia/.zprofile || \
+    (echo; echo "eval \"\$(${BREW} shellenv)\"") >> /Users/julia/.zprofile
+
+# The Homebrew installer installs the Command Line Tools and switches the
+# active developer directory to them (`xcode-select --switch
+# /Library/Developer/CommandLineTools`), silently undoing 00-select-xcode.sh.
+# CI needs full Xcode: switch back.
+if [ -d /Applications/Xcode.app ]; then
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer/
+fi

--- a/macos-seatbelt/automacci/scripts/03-install-julia.sh
+++ b/macos-seatbelt/automacci/scripts/03-install-julia.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Create .bash_profile for juliaup to modify
-sudo -i -u julia touch /Users/julia/.bash_profile
+sudo -H -u julia touch /Users/julia/.bash_profile
 
-# Install juliaup
-sudo -i -u julia curl -fsSL https://install.julialang.org | sh -s -- -y
+# Install juliaup. The whole pipeline must run as julia — with a bare
+# `sudo -u julia curl ... | sh`, only curl runs as julia; the installer
+# itself runs as the caller (root) and puts juliaup in the wrong home.
+sudo -H -u julia /bin/bash -c \
+    "curl -fsSL https://install.julialang.org | sh -s -- -y"
+
+# CI also wants the LTS channel available (PR #57 discussion, maleadt's
+# note 3). 'release' stays the default.
+sudo -H -u julia /Users/julia/.juliaup/bin/juliaup add lts || true

--- a/macos-seatbelt/automacci/scripts/04-install-tailscale.sh
+++ b/macos-seatbelt/automacci/scripts/04-install-tailscale.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Install Tailscale (open-source CLI variant — the GUI app is per-user and
+# wrong for headless CI) and its system daemon. Enrollment against
+# https://headscale.julialang.org needs a per-machine preauth key and is NOT
+# done here — see enroll-tailscale.sh, run from the host side over SSH.
+if [ "$(uname -m)" = "arm64" ]; then
+    BREW=/opt/homebrew/bin/brew
+else
+    BREW=/usr/local/bin/brew
+fi
+
+sudo -H -u julia "$BREW" install tailscale
+
+# Register + start the tailscaled launchd system daemon. Do NOT derive the
+# path via `brew --prefix` here: this script runs as root from a LaunchDaemon
+# with no $HOME, and brew refuses to run ("Error: $HOME must be set").
+# brew links tailscaled next to brew itself.
+"$(dirname "$BREW")/tailscaled" install-system-daemon

--- a/macos-seatbelt/automacci/scripts/05-install-ssh-key.sh
+++ b/macos-seatbelt/automacci/scripts/05-install-ssh-key.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Deploy the buildbot SSH public key into julia's authorized_keys
+# (PR #57 discussion, staticfloat's note 4). The repo was cloned by
+# 01-clone-buildkite-agent.sh; the key lives inside it.
+REPO=/Users/julia/src/sandboxed-buildkite-agent
+KEY_SRC="$REPO/agent/secrets/ssh_keys/julia_buildbot_rsa.pub"
+# location at the time of PR #57, in case it moves back:
+[ -f "$KEY_SRC" ] || KEY_SRC="$REPO/secrets/ssh_keys/julia_buildbot_rsa.pub"
+
+if [ ! -f "$KEY_SRC" ]; then
+    echo "buildbot ssh key not found in $REPO; skipping"
+    exit 1
+fi
+sudo -H -u julia mkdir -p /Users/julia/.ssh
+touch /Users/julia/.ssh/authorized_keys
+grep -qsF -f "$KEY_SRC" /Users/julia/.ssh/authorized_keys || \
+    cat "$KEY_SRC" >> /Users/julia/.ssh/authorized_keys
+chown -R julia /Users/julia/.ssh
+chmod 700 /Users/julia/.ssh
+chmod 600 /Users/julia/.ssh/authorized_keys


### PR DESCRIPTION
MDS became a paid subscription since PR #57, and building it from source (Carthage, code signing) is more work than what it provides: on Intel it is a GUI around Apple's own startosinstall, and on Apple Silicon it cannot be more unattended than Apple allows without MDM. This replaces it with scripts kept in this repo. Field-tested on four Macmini8,1 (Sequoia 15.7.7): after 'hdiutil mount http://server/ juliaci.dmg; /Volumes/JULIACI/run' in recovery plus one 'yes', a machine goes unattended to an auto-logged-in julia desktop, fully configured.

Flow: build-image.sh bundles a macOS installer app, firstboot.pkg, and launch scripts into juliaci.dmg (served over HTTP with range support). Intel deploys from recovery ('run': diskutil erase, pkg validation, startosinstall --installpackage); Apple Silicon needs one Setup Assistant click-through, then 'run-as' drives startosinstall with volume-owner credentials. firstboot.pkg suppresses Setup Assistant (system and per-user panes) and a LaunchDaemon creates the julia user (uid 601, autologin via /etc/kcpassword), names the machine <prefix>-<serial>, enables SSH + Screen Sharing, disables every form of sleep, kills Wi-Fi, fetches Xcode from the deploy server, and runs the numbered scripts: Xcode select/license, repo clone, Homebrew (Intel and AS prefixes), juliaup release+lts, tailscale (enrollment stays host-driven — enroll-tailscale.sh — so no secrets ride in the image), and the buildbot SSH key.

Fixes latent bugs from the MDS-era scripts: Homebrew shellenv hardcoded /opt/homebrew (wrong on Intel), NONINTERACTIVE=1 was scrubbed by 'sudo -i', and 'sudo -u julia curl | sh' installed juliaup as root. Hard-won macOS facts are recorded in the README's troubleshooting section (recovery forbids --eraseinstall with --volume; erase+install discards content pre-placed on the volume; a pkg's LaunchDaemon needs an explicit launchctl load when installed on a live system; 'id julia' false-positives on full-name aliases; brew cannot run as root from a LaunchDaemon; the Homebrew installer silently re-points xcode-select).
