### PR TITLE
Add FreeBSD AArch64 KVM image

### DIFF
--- a/platforms/freebsd-kvm/Makefile
+++ b/platforms/freebsd-kvm/Makefile
@@ -1,13 +1,17 @@
+ifeq (,$(ARCH))
+$(error "Architecture to build must be specified as ARCH, e.g. make base ARCH=x86_64")
+endif
+
 REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 include $(REPO_ROOT)/platforms/common.mk
 
-BASE_IMAGE := base-image/images/base.qcow2
-WORKER_IMAGE := buildkite-worker/images/worker.qcow2
+BASE_IMAGE := base-image/images/base-$(ARCH).qcow2
+WORKER_IMAGE := buildkite-worker/images/worker-$(ARCH).qcow2
 
 rwildcard = $(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 AGENT_HOOK_FILES := $(call rwildcard,$(REPO_ROOT)/agent/hooks/,*)
 AGENT_SECRET_FILES := $(call rwildcard,$(REPO_ROOT)/agent/secrets/,*)
-BASE_INPUTS := base-image/freebsd13.pkr.hcl $(wildcard base-image/setup_scripts/*) $(wildcard base-image/http/*) $(AGENT_SECRET_FILES)
+BASE_INPUTS := base-image/freebsd.pkr.hcl $(wildcard base-image/setup_scripts/*) $(wildcard base-image/http/*) $(AGENT_SECRET_FILES)
 WORKER_INPUTS := buildkite-worker/kvm_machine.pkr.hcl $(wildcard buildkite-worker/setup_scripts/*)
 
 define check_tool
@@ -18,7 +22,7 @@ endef
 
 $(eval $(call check_tool,packer))
 $(eval $(call check_tool,mkisofs))
-$(eval $(call check_tool,qemu-system-x86_64))
+$(eval $(call check_tool,qemu-system-$(ARCH)))
 $(eval $(call check_tool,virsh))
 
 define check_group
@@ -38,17 +42,17 @@ base: $(BASE_IMAGE)
 worker: $(WORKER_IMAGE)
 
 $(BASE_IMAGE): $(BASE_INPUTS) $(SECRET_VARIABLES_FILE)
-	cd base-image && packer build -force $(PACKER_ARGS) freebsd13.pkr.hcl
+	cd base-image && packer build -force $(PACKER_ARGS) -var arch="$(ARCH)" freebsd.pkr.hcl
 
 $(WORKER_IMAGE): $(WORKER_INPUTS) $(AGENT_HOOK_FILES) $(BASE_IMAGE) $(SECRET_VARIABLES_FILE)
 	cd buildkite-worker && packer build -force $(PACKER_ARGS) \
-		-var source_image="$(abspath $(BASE_IMAGE))" \
+		-var source_image="$(abspath $(BASE_IMAGE))" -var arch="$(ARCH)" \
 		kvm_machine.pkr.hcl
 
 validate: $(SECRET_VARIABLES_FILE)
-	cd base-image && packer validate -syntax-only $(PACKER_ARGS) freebsd13.pkr.hcl
+	cd base-image && packer validate -syntax-only $(PACKER_ARGS) freebsd.pkr.hcl
 	cd buildkite-worker && packer validate -syntax-only $(PACKER_ARGS) \
-		-var source_image="$(abspath $(BASE_IMAGE))" \
+		-var source_image="$(abspath $(BASE_IMAGE))" -var arch="$(ARCH)" \
 		kvm_machine.pkr.hcl
 
 clean:

--- a/platforms/freebsd-kvm/README.md
+++ b/platforms/freebsd-kvm/README.md
@@ -4,24 +4,29 @@ This folder contains the configuration needed to build and deploy FreeBSD KVM im
 It is based heavily on the setup used for KVM-based Windows builds (see `../windows-kvm`).
 By "based heavily," we really mean copy-pasta'd; eventually, both should be refactored to use a common setup.
 
+Both x86-64 and AArch64 images can be built.
+The Make variable `ARCH` must be provided and set to either `x86_64` or `aarch64`.
+Image names are suffixed with the architecture.
+Note that the FreeBSD version may differ depending on the architecture; see below.
+
 ## Images
 
 There are two chunks of configuration here:
 
 - `base-image`: This defines the rules necessary to create a base FreeBSD image.
   It downloads the official ISO, sets up user profiles, installs necessary tools, etc.
-  Output is saved to `base-image/images/base.qcow2`.
+  Output is saved to `base-image/images/base-<arch>.qcow2`.
 
-- `buildkite-worker`: This builds one generic worker image at `buildkite-worker/images/worker.qcow2`.
+- `buildkite-worker`: This builds one generic worker image at `buildkite-worker/images/worker-<arch>.qcow2`.
   The scheduler creates per-job overlays from that image and injects the Buildkite token, agent name, agent tags, and acquired job ID at runtime through guest-exec.
   Queue and tag values come from `config.toml` at runtime, so all FreeBSD KVM runner groups can share the same worker image.
 
-Build images from this directory with `make base`, `make worker`, or `make all`.
+Build images from this directory for a given architecture with `make base ARCH=<arch>`, `make worker ARCH=<arch>`, or `make all ARCH=<arch>`.
 The worker target depends on the base target and rebuilds when the relevant packer inputs, setup scripts, hooks, or secrets change.
 
 ## System Version
 
-The images here currently use *FreeBSD 13.4-RELEASE*.
+The images here currently use FreeBSD 13.4-RELEASE on x86-64 and FreeBSD 14.1-RELEASE on AArch64.
 
 Generally speaking, binaries built on FreeBSD version `x` are incompatible with FreeBSD version `x - 1`.
 However, the opposite is not true: binaries built on older versions are forward-compatible.
@@ -30,4 +35,4 @@ This often means that we end up staying on a version of FreeBSD after its offici
 In practice, this really only affects the availability of up-to-date software (should be fine) and where we need to go to fetch the ISO:
 
 - Old versions: <http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/ISO-IMAGES/> (HTTP only, no HTTPS)
-- Current releases: <https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/>
+- Current releases: <https://download.freebsd.org/releases/ISO-IMAGES/>

--- a/platforms/freebsd-kvm/base-image/freebsd.pkr.hcl
+++ b/platforms/freebsd-kvm/base-image/freebsd.pkr.hcl
@@ -1,3 +1,13 @@
+variable "arch" {
+    type = string
+    description = "Architecture of the VM to build"
+
+    validation {
+        condition = var.arch == "x86_64" || var.arch == "aarch64"
+        error_message = "Unrecognized arch; must be x86_64 or aarch64"
+    }
+}
+
 variable "username" {
     type = string
     default = "julia"
@@ -8,12 +18,33 @@ variable "password" {
     sensitive = true
 }
 
-source "qemu" "freebsd13" {
+locals {
+    # Default versions used by architecture; building for a given architecture will give
+    # you the listed FreeBSD version. The checksum is the SHA256 of the disc1.iso.xz artifact.
+    versions = {
+        "x86_64" = {
+            "arch" = "amd64"
+            "release" = "13.4"
+            "checksum" = "e00ce3cc1b8b388dfea4f8557d490eef6d287e0bd0a64d7d5862b4b324d5f909"
+        }
+        "aarch64" = {
+            "arch" = "arm64-aarch64"
+            "release" = "14.1"
+            "checksum" = "c3c3c6be171359234639260cb9f19ced14dce3b053dd0a6eb3fc8a3165cef926"
+        }
+    }
+    version = lookup(local.versions, var.arch)
+    release = lookup(local.version, "release")
+    url_arch = lookup(local.version, "arch")
+    iso_name = "FreeBSD-${local.release}-RELEASE-${local.url_arch}-disc1.iso.xz"
+}
+
+source "qemu" "freebsd" {
     iso_urls = [
-        "http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/ISO-IMAGES/13.4/FreeBSD-13.4-RELEASE-amd64-disc1.iso.xz",
-        "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/13.4/FreeBSD-13.4-RELEASE-amd64-disc1.iso.xz",
+        "http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/ISO-IMAGES/${local.release}/${local.iso_name}",
+        "https://download.freebsd.org/ftp/releases/ISO-IMAGES/${local.release}/${local.iso_name}",
     ]
-    iso_checksum = "e00ce3cc1b8b388dfea4f8557d490eef6d287e0bd0a64d7d5862b4b324d5f909"
+    iso_checksum = lookup(local.version, "checksum")
 
     # Note, you may need to tune this if you're on a slow computer ;)
     boot_wait = "5s"
@@ -51,7 +82,7 @@ source "qemu" "freebsd13" {
 }
 
 build {
-    sources = ["source.qemu.freebsd13"]
+    sources = ["source.qemu.freebsd"]
 
     provisioner "file" {
         source = "../../../agent/secrets/ssh_keys"

--- a/platforms/freebsd-kvm/buildkite-worker/config.toml.example
+++ b/platforms/freebsd-kvm/buildkite-worker/config.toml.example
@@ -2,11 +2,12 @@
 # Cluster agents can only listen to a single queue, so a machine that should
 # serve both the `build` and `test` queues defines one group per queue.
 [scheduler]
-logdir="@scratch/freebsd-kvm-logs"
+logdir="@scratch/freebsd-x86_64-kvm-logs"
 # KVM guests use 4 GiB RAM per allocated vCPU; keep total_cpus within host RAM.
 total_cpus=24
 
-[freebsd13-builder]
+# The guest architecture is included in the group name and in the group's tags
+[freebsd-x86_64-builder]
 backend="kvm"
 guest="freebsd"
 queues="build"
@@ -22,11 +23,12 @@ priority=1
 #cachedir="/data/agent_build"
 #tempdir="/data/agent_tmp"
 
-[freebsd13-builder.tags]
+[freebsd-x86_64-builder.tags]
 # Manually override this to say `freebsd`, even though we're on a linux host
 os="freebsd"
+arch="x86_64"
 
-[freebsd13-tester]
+[freebsd-x86_64-tester]
 backend="kvm"
 guest="freebsd"
 queues="test"
@@ -34,5 +36,6 @@ job_cpus=8
 max_jobs=2
 priority=2
 
-[freebsd13-tester.tags]
+[freebsd-x86_64-tester.tags]
 os="freebsd"
+arch="x86_64"

--- a/platforms/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl
+++ b/platforms/freebsd-kvm/buildkite-worker/kvm_machine.pkr.hcl
@@ -22,7 +22,11 @@ variable "source_image" {
     type = string
 }
 
-source "qemu" "freebsd13" {
+variable "arch" {
+    type = string
+}
+
+source "qemu" "freebsd" {
     iso_url = "file:${var.source_image}"
     iso_checksum = "none"
     disk_image = true
@@ -48,7 +52,7 @@ source "qemu" "freebsd13" {
 }
 
 build {
-    sources = ["source.qemu.freebsd13"]
+    sources = ["source.qemu.freebsd"]
 
     provisioner "file" {
         sources = [

--- a/platforms/freebsd-kvm/buildkite-worker/kvm_machine.xml.template
+++ b/platforms/freebsd-kvm/buildkite-worker/kvm_machine.xml.template
@@ -2,7 +2,7 @@
   <name>${agent_hostname}</name>
   <metadata>
     <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
-      <libosinfo:os id="http://freebsd.org/freebsd/13.4"/>
+      <libosinfo:os id="http://freebsd.org/freebsd/${release}"/>
     </libosinfo:libosinfo>
   </metadata>
   <memory unit='KiB'>${memory_kb}</memory>
@@ -12,7 +12,7 @@
     <partition>/machine</partition>
   </resource>
   <os>
-    <type arch='x86_64' machine='pc'>hvm</type>
+    <type arch='${arch}' machine='pc'>hvm</type>
     <boot dev='hd'/>
   </os>
   <features>
@@ -33,7 +33,7 @@
     <suspend-to-disk enabled='no'/>
   </pm>
   <devices>
-    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <emulator>/usr/bin/qemu-system-${arch}</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='${os_disk_path}' index='1'/>

--- a/platforms/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
+++ b/platforms/freebsd-kvm/buildkite-worker/setup_scripts/install-buildkite-agent.sh
@@ -9,7 +9,7 @@ echo "-> Installing buildkite-agent"
 # We want to install buildkite in the same way as the port so that we can use it as
 # a system service but we want to use buildkite's official binaries and distribution
 # info to ensure consistency with other systems.
-URL="https://github.com/buildkite/agent/releases/download/v3.129.0/buildkite-agent-freebsd-amd64-3.129.0.tar.gz"
+URL="https://github.com/buildkite/agent/releases/download/v3.129.0/buildkite-agent-freebsd-$(uname -m)-3.129.0.tar.gz"
 FILENAME="$(basename "${URL}")"
 
 mkdir -p /tmp/buildkite-install

--- a/src/backends/kvm.jl
+++ b/src/backends/kvm.jl
@@ -73,7 +73,8 @@ function kvm_image_dir(brg::BuildkiteRunnerGroup)
 end
 
 function kvm_pristine_os_image(brg::BuildkiteRunnerGroup)
-    return joinpath(kvm_image_dir(brg), "worker.qcow2")
+    suffix = brg.guest == "freebsd" ? ('-' * brg.tags["arch"]) : ""
+    return joinpath(kvm_image_dir(brg), "worker$(suffix).qcow2")
 end
 
 function kvm_pristine_cache_image(brg::BuildkiteRunnerGroup)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1201,7 +1201,7 @@ end
     Base.write(token_path, "secret-token\n")
     chmod(token_path, 0o600)
 
-    brg = BuildkiteRunnerGroup("freebsd13", Dict{String,Any}(
+    brg = BuildkiteRunnerGroup("freebsd-x86_64", Dict{String,Any}(
         "queues" => "build",
         "backend" => BACKEND_KVM,
         "guest" => "freebsd",
@@ -1218,14 +1218,14 @@ end
 
     # The orphan sweep matches domains by hostname-qualified prefix and by the
     # cache overlay basename inside the scheduler's roots.
-    @test backend.groups == ["freebsd13"]
-    @test only(backend.domain_prefixes) == string("freebsd13-", SandboxedBuildkiteAgent.get_short_hostname(), ".")
+    @test backend.groups == ["freebsd"]
+    @test only(backend.domain_prefixes) == string("freebsd-x86_64-", SandboxedBuildkiteAgent.get_short_hostname(), ".")
     @test backend.scratch_roots == [joinpath(tempdir(brg), "kvm-agent-scratch")]
     @test backend.cache_roots == [SandboxedBuildkiteAgent.cachedir(brg)]
     @test basename(kvm_cache_overlay_path(plan)) == "cache.qcow2-1"
-    # The Makefiles produce worker.qcow2 (+ the "-1" cache disk) under
+    # The Makefiles produce worker-<arch>.qcow2 (+ the "-1" cache disk) under
     # platforms/<guest>-kvm/buildkite-worker/images/.
-    @test endswith(kvm_pristine_os_image(brg), joinpath("platforms", "freebsd-kvm", "buildkite-worker", "images", "worker.qcow2"))
+    @test endswith(kvm_pristine_os_image(brg), joinpath("platforms", "freebsd-kvm", "buildkite-worker", "images", "worker-x86_64.qcow2"))
     @test kvm_pristine_cache_image(brg) == string(kvm_pristine_os_image(brg), "-1")
 
     handle = KVMHandle(


### PR DESCRIPTION
Notable changes:

- `ARCH` must be specified and set to `x86_64` or `aarch64` when running `make` under `platforms/freebsd-kvm`. This gets forwarded to the Packer variable `arch` and is also used to check for the appropriate QEMU executable. This avoids duplicating 99% of the configuration as compared to separating it into a different directory.
- The base and worker qcow2 image files for FreeBSD are suffixed with the architecture, e.g., `worker-x86_64.qcow2`. This facilitates building for either architecture without interfering with existing build artifacts.
- The build source (and associated Packer file) is now `freebsd` instead of `freebsd13`. This is because different OS versions are used on x86-64 and AArch64, and they aren't both 13.x.
- Buildkite Runner groups should include the architecture as part of the name. This is not enforced, but it's one way to ensure separation.

You may be wondering why we're not using the same OS version across architectures. This is to match BinaryBuilder.jl, which targets 13.4 for x86-64 and 14.1 for AArch64. Were we to use 13.4 for AArch64, BinaryBuilder-built dependencies may not work, since they were built with a later version. Were we to use 14.1 for x86-64, we would be effectively dropping support for FreeBSD 13. That's _probably_ okay, but better to avoid that kind of silent breakage whenever possible.

I don't actually know where our Linux AArch64 CI runs and whether it's native AArch64 or emulated. I also don't know how poor the performance is when using QEMU with a different architecture on the guest than the host, but I assume not great.

Importantly, I have not tested this and have no idea whether what I've implemented works correctly, breaks existing setups, or causes spontaneous combustion. Suggestions for testing would be welcome. I think Elliot had helped me with that several years ago but it's been too long...